### PR TITLE
Adding android:usesCleartextTraffic for Android8+ devices

### DIFF
--- a/pretixprint/app/src/main/AndroidManifest.xml
+++ b/pretixprint/app/src/main/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:logo="@drawable/ic_logo"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <activity
             android:name="eu.pretix.pretixprint.ui.SettingsActivity"
             android:label="@string/title_activity_main">


### PR DESCRIPTION
Android 8+ devices will generally not permit any cleartext-traffic - adding this fixes the issue.

Tested von Pixel XL with Android P.