### PR TITLE
Add support for Brother label printers

### DIFF
--- a/pretixprint/app/src/foss/java/eu/pretix/pretixprint/byteprotocols/Registry.kt
+++ b/pretixprint/app/src/foss/java/eu/pretix/pretixprint/byteprotocols/Registry.kt
@@ -4,5 +4,6 @@ val protocols = listOf<ByteProtocolInterface<*>>(
         FGL(),
         SLCS(),
         GraphicESCPOS(),
-        ESCPOS()
+        ESCPOS(),
+        BrotherRaster()
 )

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOS.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOS.kt
@@ -13,6 +13,7 @@ import com.zebra.sdk.comm.UsbConnection
 import com.zebra.sdk.printer.ZebraPrinter
 import com.zebra.sdk.printer.ZebraPrinterFactory
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.ui.LinkOSSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
@@ -23,14 +24,18 @@ import java.io.IOException
 
 class LinkOS : CustomByteProtocol<Bitmap> {
     override val identifier = "LinkOS"
-    override fun allowedForUsecase(type: String): Boolean {
-        return type != "receipt"
-    }
-
     override val defaultDPI = 203
     override val demopage = "demopage_8in_3.25in.pdf"
 
     override val nameResource = R.string.protocol_linkos
+
+    override fun allowedForUsecase(type: String): Boolean {
+        return type != "receipt"
+    }
+
+    override fun allowedForConnection(type: ConnectionType): Boolean {
+        return true
+    }
 
     override fun convertPageToBytes(img: Bitmap, isLastPage: Boolean, previousPage: Bitmap?, conf: Map<String, String>, type: String): ByteArray {
         val ostream = ByteArrayOutputStream()

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
@@ -21,6 +21,7 @@ import com.zebra.sdk.common.card.jobSettings.ZebraCardJobSettingNames
 import com.zebra.sdk.common.card.printer.ZebraCardPrinter
 import com.zebra.sdk.common.card.printer.ZebraCardPrinterFactory
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.ui.LinkOSCardSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
@@ -32,13 +33,18 @@ import java.util.concurrent.TimeUnit
 
 class LinkOSCard : CustomByteProtocol<Bitmap> {
     override val identifier = "LinkOSCard"
-    override fun allowedForUsecase(type: String): Boolean {
-        return type != "receipt"
-    }
     override val defaultDPI = 300
     override val demopage = "CR80.pdf"
 
     override val nameResource = R.string.protocol_linkoscard
+
+    override fun allowedForUsecase(type: String): Boolean {
+        return type != "receipt"
+    }
+
+    override fun allowedForConnection(type: ConnectionType): Boolean {
+        return true
+    }
 
     override fun convertPageToBytes(img: Bitmap, isLastPage: Boolean, previousPage: Bitmap?, conf: Map<String, String>, type: String): ByteArray {
         val ostream = ByteArrayOutputStream()

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/Registry.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/Registry.kt
@@ -5,6 +5,7 @@ val protocols = listOf<ByteProtocolInterface<*>>(
         SLCS(),
         ESCPOS(),
         GraphicESCPOS(),
+        BrotherRaster(),
         LinkOSCard(),
         LinkOS()
 )

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
@@ -101,10 +101,15 @@ class BrotherRaster : StreamByteProtocol<Bitmap> {
         ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'a'.code.toByte(), 0x01)) // Mode: raster
         ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'S'.code.toByte())) // request statusinfo
 
+        // Note: printing twoColor labels doesn't support the quality flag
+        var mediaFlag = 0x86
+        if (!label.twoColor && conf.get("hardware_${type}printer_quality") == "true") {
+            mediaFlag = 0xC6
+        }
         val rasterHeight = maxHeight * (if(label.twoColor) 2 else 1)
         ostream.write(byteArrayOf(
             0x1B, 'i'.code.toByte(), 'z'.code.toByte(), // Media information
-            if (label.twoColor) 0x86.toByte() else 0xC6.toByte(),
+            mediaFlag.toByte(),
             if (label.continuous) 0x0A else 0x0B,
             label.width.toByte(),
             if (label.continuous) 0x00 else label.height.toByte(),

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
@@ -1,0 +1,193 @@
+package eu.pretix.pretixprint.byteprotocols
+
+import android.graphics.Bitmap
+import android.graphics.Matrix
+import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.ui.BrotherRasterSettingsFragment
+import eu.pretix.pretixprint.ui.SetupFragment
+import java8.util.concurrent.CompletableFuture
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import kotlin.math.min
+
+// https://download.brother.com/welcome/docp100278/cv_ql800_eng_raster_100.pdf
+// https://download.brother.com/welcome/docp100366/cv_ql1100_eng_raster_100.pdf
+class BrotherRaster : StreamByteProtocol<Bitmap> {
+    override val identifier = "BrotherRaster"
+    override val nameResource = R.string.protocol_brother
+    override val defaultDPI = 300
+    override val demopage = "demopage_8in_3.25in.pdf"
+
+    // Label data list extracted from
+    // https://download.brother.com/welcome/docp100366/cv_ql1100_eng_raster_100.pdf
+    enum class Label(val id: Int, val width: Int, val height: Int, val continuous: Boolean, val printableWidth: Int, val printableHeight: Int) {
+        c12mm(257, 12, 0, true, 106, 0),
+        c29mm(258, 29, 0, true, 306, 0),
+        c38mm(264, 38, 0, true, 413, 0),
+        c50mm(262, 50, 0, true, 554, 0),
+        c54mm(261, 54, 0, true, 590, 0),
+        c62mm(259, 62, 0, true, 696, 0),
+        c102mm(260, 102, 0, true, 1164, 0),
+        c103mm(265, 103, 0, true, 1200, 0),
+        d17x54(269, 17, 54, false, 165, 566),
+        d17x87(270, 17, 87, false, 165, 956),
+        d23x23(370, 23, 23, false, 236, 202),
+        d29x42(358, 29, 42, false, 306, 425),
+        d29x90(271, 29, 90, false, 306, 991),
+        d38x90(272, 38, 90, false, 413, 991),
+        d39x48(367, 39, 48, false, 425, 495),
+        d52x29(374, 52, 29, false, 578, 271),
+        d60x86(383, 60, 86, false, 672, 954),
+        d62x29(274, 62, 29, false, 696, 271),
+        d62x100(275, 62, 100, false, 696, 1109),
+        d102x51(365, 102, 51, false, 1164, 526),
+        d102x152(366, 102, 152, false, 1164, 1660),
+        d103x164(385, 103, 164, false, 1200, 1822);
+
+        fun size() : String {
+            if (this.continuous) {
+                return "${this.width} mm"
+            }
+            return "${this.width} mm × ${this.height} mm"
+        }
+
+        override fun toString(): String {
+            return size()
+        }
+    }
+
+    override fun allowedForUsecase(type: String): Boolean {
+        return type != "receipt"
+    }
+
+    override fun convertPageToBytes(img: Bitmap, isLastPage: Boolean, previousPage: Bitmap?, conf: Map<String, String>, type: String): ByteArray {
+        val ostream = ByteArrayOutputStream()
+
+        val label = Label.values().find { it.name == conf.get("hardware_${type}printer_label") }!!
+        val targetWidth = label.printableWidth
+
+        val matrix = Matrix()
+        var imgW = img.width
+        var imgH = img.height
+        // rotate
+        if (conf.get("hardware_${type}printer_rotate90") == "true") {
+            matrix.setRotate(90f)
+            imgH = img.width
+            imgW = img.height
+        }
+        // resize
+        var targetHeight = imgH
+        if (imgW > targetWidth) {
+            targetHeight = (targetWidth.toFloat() / imgW.toFloat() * imgH.toFloat()).toInt()
+            val sx: Float = targetWidth / imgW.toFloat()
+            val sy: Float = targetHeight / imgH.toFloat()
+            matrix.postScale(sx, sy)
+        }
+        // flip
+        matrix.postScale(-1f, 1f, targetWidth / 2f, targetHeight / 2f)
+        val scaled = Bitmap.createBitmap(img, 0, 0, img.width, img.height, matrix, true)
+
+        val maxHeight = scaled.height.coerceAtLeast(label.printableHeight)
+
+        ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'a'.code.toByte(), 0x01)) // Mode: raster
+        ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'S'.code.toByte())) // request statusinfo
+
+        ostream.write(byteArrayOf(
+            0x1B, 'i'.code.toByte(), 'z'.code.toByte(), // Media information
+            0xC6.toByte(),
+            if (label.continuous) 0x0A else 0x0B,
+            label.width.toByte(),
+            if (label.continuous) 0x00 else label.height.toByte(),
+            maxHeight.toByte(),
+            (maxHeight shr 8).toByte(),
+            (maxHeight shr 16).toByte(),
+            (maxHeight shr 24).toByte(),
+            if (previousPage != null) 0x01 else 0x00,
+            0x00
+        ))
+        ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'K'.code.toByte(), 0x08)) // Cut at end, 300dpi
+        ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'M'.code.toByte(), 0x40)) // Auto Cut
+        ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'A'.code.toByte(), 0x01)) // Cut after every label
+        if (label.continuous) {
+            ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'd'.code.toByte(), 0x23, 0x00)) // Margins: 3mm
+        } else {
+            ostream.write(byteArrayOf(0x1B, 'i'.code.toByte(), 'd'.code.toByte(), 0x00, 0x00)) // Margins: 0mm
+        }
+
+        val pixels = IntArray(scaled.width * scaled.height)
+        scaled.getPixels(pixels, 0, scaled.width, 0, 0, scaled.width, scaled.height)
+        val bytewidth = scaled.width / 8
+        for (y in 0 until maxHeight) {
+            val row = ByteArray(bytewidth)
+            for (xoffset in 0 until bytewidth) {
+                var col = 0
+                // check for overprinting (more height than scaled image)
+                if (y <= scaled.height) {
+                    for (j in 0..7) {
+                        val px = pixels[min((xoffset * 8 + j) + scaled.width * y, pixels.size - 1)]
+                        if ((px shr 24) and 0xff > 128 && ((px shr 16) and 0xff < 128 || (px shr 8) and 0xff < 128 || px and 0xff < 128)) {
+                            // A > 128 && (R < 128 || G < 128 || B < 128)
+                            col = col or (1 shl (7 - j))
+                        }
+                    }
+                } else {
+                    // fill rest of paper with white nothingness
+                    col = 0
+                }
+                row[xoffset] = col.toByte()
+            }
+
+            ostream.write('g'.code)
+            ostream.write(0x00) // default color
+            val len = min(90, row.size)
+            ostream.write(len)
+            ostream.write(row, 0, len)
+            ostream.flush()
+        }
+
+        // Print command with feeding
+        if (isLastPage) {
+            ostream.write(0x1A)
+        } else {
+            ostream.write(0x0C)
+        }
+
+        /*
+        val sb = StringBuffer(ostream.size()*3)
+        for (b in ostream.toByteArray()) {
+            var i = b.toInt() and 0xFF
+            sb.append(" " + "0123456789ABCDEF"[i shr 4] + "0123456789ABCDEF"[i and 0x0F])
+        }
+        */
+
+        return ostream.toByteArray()
+    }
+
+    override fun send(pages: List<CompletableFuture<ByteArray>>, istream: InputStream, ostream: OutputStream, conf: Map<String, String>, type: String) {
+        // Invalidate
+        for (i in 0 until 400) {
+            ostream.write(0x00)
+        }
+        ostream.flush()
+
+        // Initialize
+        ostream.write(byteArrayOf(0x1B, '@'.code.toByte()))
+
+        for (f in pages) {
+            ostream.write(f.get())
+            ostream.flush()
+        }
+
+        val wap = Integer.valueOf(conf.get("hardware_${type}printer_waitafterpage") ?: "2000")
+        Thread.sleep(wap.toLong())
+    }
+
+    override fun createSettingsFragment(): SetupFragment? {
+        return BrotherRasterSettingsFragment()
+    }
+
+    override fun inputClass(): Class<Bitmap> {
+        return Bitmap::class.java
+    }
+}

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
@@ -59,8 +59,12 @@ class BrotherRaster : StreamByteProtocol<Bitmap> {
         d102x152(366, 102, 152, false, 1164, 1660),
         d103x164(385, 103, 164, false, 1200, 1822);
 
+        fun size(): String {
+            return if (this.continuous) "${this.width} mm" else "${this.width} mm × ${this.height} mm"
+        }
+
         override fun toString(): String {
-            var n = if (this.continuous) "${this.width} mm" else "${this.width} mm × ${this.height} mm"
+            var n = size()
             if (this.twoColor) {
                 n += " (red/black)"
             }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
@@ -3,6 +3,8 @@ package eu.pretix.pretixprint.byteprotocols
 import android.graphics.Bitmap
 import android.graphics.Matrix
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.ConnectionType
+import eu.pretix.pretixprint.connections.NetworkConnection
 import eu.pretix.pretixprint.ui.BrotherRasterSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
@@ -67,6 +69,10 @@ class BrotherRaster : StreamByteProtocol<Bitmap> {
 
     override fun allowedForUsecase(type: String): Boolean {
         return type != "receipt"
+    }
+
+    override fun allowedForConnection(type: ConnectionType): Boolean {
+        return type is NetworkConnection
     }
 
     override fun convertPageToBytes(img: Bitmap, isLastPage: Boolean, previousPage: Bitmap?, conf: Map<String, String>, type: String): ByteArray {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
@@ -19,8 +19,18 @@ class BrotherRaster : StreamByteProtocol<Bitmap> {
     override val defaultDPI = 300
     override val demopage = "demopage_8in_3.25in.pdf"
 
-    // Label data list extracted from
-    // https://download.brother.com/welcome/docp100366/cv_ql1100_eng_raster_100.pdf
+    /**
+     * Label data list extracted from 2.3.2 Page size in the following documents:
+     * @url https://download.brother.com/welcome/docp100278/cv_ql800_eng_raster_100.pdf
+     * @url https://download.brother.com/welcome/docp100366/cv_ql1100_eng_raster_100.pdf
+     *
+     * @param width the paper/label width in mm. See 2.3.2 Page size, column Tape/Label Size
+     * @param height the paper/label height in mm. See 2.3.2 Page size, column Tape/Label Size. 0 for endless paper
+     * @param continuous does the roll contain single labels (false) or is endless paper (true)?
+     * @param printableWidth in dots. See 2.3.2 Page size, column 3 Print area width
+     * @param printableHeight in dots. See 2.3.2 Page size, column 4 Print area length. 0 for endless paper
+     * @param twoColor some labels support red/black
+     */
     enum class Label(val id: Int, val width: Int, val height: Int, val continuous: Boolean, val printableWidth: Int, val printableHeight: Int, val twoColor: Boolean = false) {
         c12mm(257, 12, 0, true, 106, 0),
         c29mm(258, 29, 0, true, 306, 0),
@@ -179,8 +189,7 @@ class BrotherRaster : StreamByteProtocol<Bitmap> {
             ostream.flush()
         }
 
-        val wap = Integer.valueOf(conf.get("hardware_${type}printer_waitafterpage") ?: "2000")
-        Thread.sleep(wap.toLong())
+        Thread.sleep(2000)
     }
 
     override fun createSettingsFragment(): SetupFragment? {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
@@ -16,7 +16,7 @@ import kotlin.math.min
 class BrotherRaster : StreamByteProtocol<Bitmap> {
     override val identifier = "BrotherRaster"
     override val nameResource = R.string.protocol_brother
-    override val defaultDPI = 300
+    override val defaultDPI = 600
     override val demopage = "demopage_8in_3.25in.pdf"
 
     /**

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/ESCPOS.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/ESCPOS.kt
@@ -1,6 +1,7 @@
 package eu.pretix.pretixprint.byteprotocols
 
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.ui.ESCPOSSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
@@ -17,6 +18,10 @@ class ESCPOS : StreamByteProtocol<ByteArray> {
 
     override fun allowedForUsecase(type: String): Boolean {
         return type == "receipt"
+    }
+
+    override fun allowedForConnection(type: ConnectionType): Boolean {
+        return true
     }
 
     override fun convertPageToBytes(img: ByteArray, isLastPage: Boolean, previousPage: ByteArray?, conf: Map<String, String>, type: String): ByteArray {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/FGL.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/FGL.kt
@@ -3,6 +3,7 @@ package eu.pretix.pretixprint.byteprotocols
 import android.graphics.Bitmap
 import androidx.fragment.app.Fragment
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.ui.FGLSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java.io.ByteArrayOutputStream
@@ -20,6 +21,10 @@ class FGL : StreamByteProtocol<Bitmap> {
 
     override fun allowedForUsecase(type: String): Boolean {
         return type != "receipt"
+    }
+
+    override fun allowedForConnection(type: ConnectionType): Boolean {
+        return true
     }
 
     // With diffRendering=true, in a multi-page file we'd only send the pixels that changed compared

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/GraphicESCPOS.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/GraphicESCPOS.kt
@@ -9,6 +9,7 @@ import com.github.anastaciocintra.escpos.image.CoffeeImage
 import com.github.anastaciocintra.escpos.image.EscPosImage
 import com.github.anastaciocintra.escpos.image.GraphicsImageWrapper
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.ui.GraphicESCPOSSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
@@ -26,6 +27,10 @@ class GraphicESCPOS : StreamByteProtocol<Bitmap> {
 
     override fun allowedForUsecase(type: String): Boolean {
         return type != "receipt"
+    }
+
+    override fun allowedForConnection(type: ConnectionType): Boolean {
+        return true
     }
 
     override fun convertPageToBytes(img: Bitmap, isLastPage: Boolean, previousPage: Bitmap?, conf: Map<String, String>, type: String): ByteArray {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/Interface.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/Interface.kt
@@ -3,6 +3,7 @@ package eu.pretix.pretixprint.byteprotocols
 import android.content.Context
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
+import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
 import java.io.IOException
@@ -16,6 +17,7 @@ interface ByteProtocolInterface<T> {
     val demopage: String
 
     fun allowedForUsecase(type: String): Boolean
+    fun allowedForConnection(type: ConnectionType): Boolean
     fun convertPageToBytes(img: T, isLastPage: Boolean, previousPage: T?, conf: Map<String, String>, type: String): ByteArray
     fun createSettingsFragment(): SetupFragment?
     fun inputClass(): Class<T>

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/SLCS.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/SLCS.kt
@@ -3,6 +3,7 @@ package eu.pretix.pretixprint.byteprotocols
 import android.graphics.Bitmap
 import androidx.fragment.app.Fragment
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.ui.SLCSSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
@@ -20,6 +21,10 @@ class SLCS : StreamByteProtocol<Bitmap> {
 
     override fun allowedForUsecase(type: String): Boolean {
         return type != "receipt"
+    }
+
+    override fun allowedForConnection(type: ConnectionType): Boolean {
+        return true
     }
 
     override fun convertPageToBytes(img: Bitmap, isLastPage: Boolean, previousPage: Bitmap?, conf: Map<String, String>, type: String): ByteArray {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
@@ -144,6 +144,9 @@ class UsbOutputStream(usbManager: UsbManager, usbDevice: UsbDevice, val compat: 
             while (count > 0) {
                 val l = min(usbEndpoint!!.maxPacketSize, count)
                 val snd = usbConnection!!.bulkTransfer(usbEndpoint, bytes, offset, l, 10000)
+                if (snd < 0) {
+                    throw IOException("Error sending USB data.")
+                }
                 count -= snd
                 offset += snd
             }
@@ -363,15 +366,12 @@ class USBConnection : ConnectionType {
                             } catch (e: PrintError) {
                                 e.printStackTrace()
                                 err = PrintException(context.applicationContext.getString(R.string.err_job_io, e.message))
-                                return
                             } catch (e: IOException) {
                                 e.printStackTrace()
                                 err = PrintException(context.applicationContext.getString(R.string.err_job_io, e.message))
-                                return
                             }
                         } else {
                             err = PrintException(context.getString(R.string.err_usb_permission_denied))
-                            return
                         }
                     }
                 } finally {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
@@ -23,6 +23,7 @@ class BrotherRasterSettingsFragment : SetupFragment() {
             savedInstanceState: Bundle?
     ): View {
         val view = inflater.inflate(R.layout.fragment_brotherraster_settings, container, false)
+        val proto = BrotherRaster()
 
         val labelAdapter = ArrayAdapter(requireContext(), R.layout.list_item, BrotherRaster.Label.values())
         (view.findViewById<TextInputLayout>(R.id.tilLabel).editText as? AutoCompleteTextView)?.setAdapter(labelAdapter)
@@ -35,11 +36,6 @@ class BrotherRasterSettingsFragment : SetupFragment() {
             (view.findViewById<TextInputLayout>(R.id.tilLabel).editText as? AutoCompleteTextView)?.setText(chosenLabel, false)
         }
 
-        val currentWaitAfterPage = ((activity as PrinterSetupActivity).settingsStagingArea.get(
-                "hardware_${useCase}printer_waitafterpage"
-        )) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_waitafterpage", "2000")
-        view.findViewById<TextInputEditText>(R.id.teWaitAfterPage).setText(currentWaitAfterPage)
-
         val currentRotate90 = ((activity as PrinterSetupActivity).settingsStagingArea.get(
                 "hardware_${useCase}printer_rotate90"
         )?.toBoolean() ) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_rotate90", "false")!!.toBoolean()
@@ -49,23 +45,18 @@ class BrotherRasterSettingsFragment : SetupFragment() {
             back()
         }
         view.findViewById<Button>(R.id.btnNext).setOnClickListener {
-            val wap = view.findViewById<TextInputEditText>(R.id.teWaitAfterPage).text.toString()
             val label = view.findViewById<TextInputLayout>(R.id.tilLabel).editText?.text.toString()
             val rotate90 = view.findViewById<SwitchMaterial>(R.id.swRotate90).isChecked
-            if (TextUtils.isEmpty(wap)) {
-                view.findViewById<TextInputEditText>(R.id.teWaitAfterPage).error = getString(R.string.err_field_required)
-            } else if (TextUtils.isEmpty(label)) {
+            if (TextUtils.isEmpty(label)) {
                 view.findViewById<TextInputEditText>(R.id.tilLabel).error = getString(R.string.err_field_required)
-            } else if (!TextUtils.isDigitsOnly(wap)) {
-                view.findViewById<TextInputEditText>(R.id.teWaitAfterPage).error = getString(R.string.err_field_invalid)
             } else {
                 val mappedLabel = BrotherRaster.Label.values().find { it.toString() == label }!!.name
 
                 (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_rotate90", rotate90.toString())
                 (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_label",
                     mappedLabel)
-                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_waitafterpage",
-                        wap)
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_dpi",
+                    proto.defaultDPI.toString())
                 (activity as PrinterSetupActivity).startFinalPage()
             }
         }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
@@ -41,11 +41,17 @@ class BrotherRasterSettingsFragment : SetupFragment() {
         )?.toBoolean() ) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_rotate90", "false")!!.toBoolean()
         view.findViewById<SwitchMaterial>(R.id.swRotate90).isChecked = currentRotate90
 
+        val currentQuality = ((activity as PrinterSetupActivity).settingsStagingArea.get(
+                "hardware_${useCase}printer_quality"
+        )?.toBoolean() ) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_quality", "false")!!.toBoolean()
+        view.findViewById<SwitchMaterial>(R.id.swQuality).isChecked = currentQuality
+
         view.findViewById<Button>(R.id.btnPrev).setOnClickListener {
             back()
         }
         view.findViewById<Button>(R.id.btnNext).setOnClickListener {
             val label = view.findViewById<TextInputLayout>(R.id.tilLabel).editText?.text.toString()
+            val quality = view.findViewById<SwitchMaterial>(R.id.swQuality).isChecked
             val rotate90 = view.findViewById<SwitchMaterial>(R.id.swRotate90).isChecked
             if (TextUtils.isEmpty(label)) {
                 view.findViewById<TextInputEditText>(R.id.tilLabel).error = getString(R.string.err_field_required)
@@ -53,6 +59,7 @@ class BrotherRasterSettingsFragment : SetupFragment() {
                 val mappedLabel = BrotherRaster.Label.values().find { it.toString() == label }!!.name
 
                 (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_rotate90", rotate90.toString())
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_quality", quality.toString())
                 (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_label",
                     mappedLabel)
                 (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_dpi",

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
@@ -1,0 +1,79 @@
+package eu.pretix.pretixprint.ui
+
+import android.os.Bundle
+import android.text.TextUtils
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
+import android.widget.Button
+import com.google.android.material.switchmaterial.SwitchMaterial
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.byteprotocols.BrotherRaster
+import org.jetbrains.anko.support.v4.defaultSharedPreferences
+
+class BrotherRasterSettingsFragment : SetupFragment() {
+
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View {
+        val view = inflater.inflate(R.layout.fragment_brotherraster_settings, container, false)
+
+        val labelAdapter = ArrayAdapter(requireContext(), R.layout.list_item, BrotherRaster.Label.values())
+        (view.findViewById<TextInputLayout>(R.id.tilLabel).editText as? AutoCompleteTextView)?.setAdapter(labelAdapter)
+
+        val chosenLabelId = ((activity as PrinterSetupActivity).settingsStagingArea.get(
+            "hardware_${useCase}printer_label"
+        )) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_label", "")
+        if (chosenLabelId?.isNotEmpty() == true) {
+            val chosenLabel = BrotherRaster.Label.values().find { it.name == chosenLabelId }.toString()
+            (view.findViewById<TextInputLayout>(R.id.tilLabel).editText as? AutoCompleteTextView)?.setText(chosenLabel, false)
+        }
+
+        val currentWaitAfterPage = ((activity as PrinterSetupActivity).settingsStagingArea.get(
+                "hardware_${useCase}printer_waitafterpage"
+        )) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_waitafterpage", "2000")
+        view.findViewById<TextInputEditText>(R.id.teWaitAfterPage).setText(currentWaitAfterPage)
+
+        val currentRotate90 = ((activity as PrinterSetupActivity).settingsStagingArea.get(
+                "hardware_${useCase}printer_rotate90"
+        )?.toBoolean() ) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_rotate90", "false")!!.toBoolean()
+        view.findViewById<SwitchMaterial>(R.id.swRotate90).isChecked = currentRotate90
+
+        view.findViewById<Button>(R.id.btnPrev).setOnClickListener {
+            back()
+        }
+        view.findViewById<Button>(R.id.btnNext).setOnClickListener {
+            val wap = view.findViewById<TextInputEditText>(R.id.teWaitAfterPage).text.toString()
+            val label = view.findViewById<TextInputLayout>(R.id.tilLabel).editText?.text.toString()
+            val rotate90 = view.findViewById<SwitchMaterial>(R.id.swRotate90).isChecked
+            if (TextUtils.isEmpty(wap)) {
+                view.findViewById<TextInputEditText>(R.id.teWaitAfterPage).error = getString(R.string.err_field_required)
+            } else if (TextUtils.isEmpty(label)) {
+                view.findViewById<TextInputEditText>(R.id.tilLabel).error = getString(R.string.err_field_required)
+            } else if (!TextUtils.isDigitsOnly(wap)) {
+                view.findViewById<TextInputEditText>(R.id.teWaitAfterPage).error = getString(R.string.err_field_invalid)
+            } else {
+                val mappedLabel = BrotherRaster.Label.values().find { it.toString() == label }!!.name
+
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_rotate90", rotate90.toString())
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_label",
+                    mappedLabel)
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_waitafterpage",
+                        wap)
+                (activity as PrinterSetupActivity).startFinalPage()
+            }
+        }
+
+        return view
+    }
+
+    override fun back() {
+        (activity as PrinterSetupActivity).startProtocolChoice()
+    }
+}

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
@@ -17,6 +17,21 @@ import org.jetbrains.anko.support.v4.defaultSharedPreferences
 
 class BrotherRasterSettingsFragment : SetupFragment() {
 
+    private fun translatedLabelName(label: BrotherRaster.Label): String {
+        var suffix = ""
+        if (label.continuous) {
+            suffix = getString(R.string.label_continuous)
+        }
+        if (label.twoColor) {
+            if (suffix != "") {
+                suffix += ", " + getString(R.string.label_two_color)
+            } else {
+                suffix = getString(R.string.label_two_color)
+            }
+        }
+        return label.size() + (if (suffix != "") " (${suffix})" else "")
+    }
+
     override fun onCreateView(
             inflater: LayoutInflater,
             container: ViewGroup?,
@@ -25,14 +40,16 @@ class BrotherRasterSettingsFragment : SetupFragment() {
         val view = inflater.inflate(R.layout.fragment_brotherraster_settings, container, false)
         val proto = BrotherRaster()
 
-        val labelAdapter = ArrayAdapter(requireContext(), R.layout.list_item, BrotherRaster.Label.values())
+        val labelAdapter = ArrayAdapter(requireContext(), R.layout.list_item, BrotherRaster.Label.values().map {
+            translatedLabelName(it)
+        })
         (view.findViewById<TextInputLayout>(R.id.tilLabel).editText as? AutoCompleteTextView)?.setAdapter(labelAdapter)
 
         val chosenLabelId = ((activity as PrinterSetupActivity).settingsStagingArea.get(
             "hardware_${useCase}printer_label"
         )) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_label", "")
         if (chosenLabelId?.isNotEmpty() == true) {
-            val chosenLabel = BrotherRaster.Label.values().find { it.name == chosenLabelId }.toString()
+            val chosenLabel = translatedLabelName(BrotherRaster.Label.values().find { it.name == chosenLabelId }!!)
             (view.findViewById<TextInputLayout>(R.id.tilLabel).editText as? AutoCompleteTextView)?.setText(chosenLabel, false)
         }
 
@@ -56,7 +73,7 @@ class BrotherRasterSettingsFragment : SetupFragment() {
             if (TextUtils.isEmpty(label)) {
                 view.findViewById<TextInputEditText>(R.id.tilLabel).error = getString(R.string.err_field_required)
             } else {
-                val mappedLabel = BrotherRaster.Label.values().find { it.toString() == label }!!.name
+                val mappedLabel = BrotherRaster.Label.values().find { translatedLabelName(it) == label }!!.name
 
                 (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_rotate90", rotate90.toString())
                 (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_quality", quality.toString())

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/ChooseProtocolFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/ChooseProtocolFragment.kt
@@ -12,6 +12,7 @@ import androidx.recyclerview.widget.RecyclerView
 import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.byteprotocols.ByteProtocolInterface
 import eu.pretix.pretixprint.byteprotocols.protocols
+import eu.pretix.pretixprint.connections.connectionTypes
 import eu.pretix.pretixprint.databinding.ItemByteProtocolBinding
 import org.jetbrains.anko.support.v4.defaultSharedPreferences
 import org.jetbrains.anko.support.v4.toast
@@ -96,6 +97,11 @@ class ChooseByteProtocolFragment : SetupFragment() {
     ): View {
         val view = inflater.inflate(R.layout.fragment_choose_byte_protocol, container, false)
 
+        val connectionIdentifier = (activity as PrinterSetupActivity).settingsStagingArea.get(
+            "hardware_${useCase}printer_connection"
+        )
+        val connection = connectionTypes.find { it.identifier == connectionIdentifier }!!
+
         val current = (activity as PrinterSetupActivity).settingsStagingArea.get(
                 "hardware_${useCase}printer_mode"
         ) ?: defaultSharedPreferences.getString("hardware_${useCase}printer_mode", "")
@@ -106,7 +112,7 @@ class ChooseByteProtocolFragment : SetupFragment() {
         val layoutManager = androidx.recyclerview.widget.LinearLayoutManager(activity)
 
         adapter.submitList(protocols.filter {
-            it.allowedForUsecase(useCase)
+            it.allowedForUsecase(useCase) && it.allowedForConnection(connection)
         })
         view.findViewById<RecyclerView>(R.id.list).adapter = adapter
         view.findViewById<RecyclerView>(R.id.list).layoutManager = layoutManager

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/USBSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/USBSettingsFragment.kt
@@ -87,7 +87,7 @@ class USBSettingsFragment : SetupFragment() {
         view.findViewById<Button>(R.id.btnAuto).setOnClickListener {
             val manager = activity!!.getSystemService(Context.USB_SERVICE) as UsbManager
             val deviceList = manager.deviceList.values.toList()
-            selector(getString(R.string.headline_found_usb_devices), deviceList.map { "${it.manufacturerName} ${it.productName} (${Integer.toHexString(it.vendorId)}:${Integer.toHexString(it.productId)})" }) { dialogInterface, i ->
+            selector(getString(R.string.headline_found_usb_devices), deviceList.map { "${it.manufacturerName} ${it.productName} (${String.format("%04x", it.vendorId)}:${String.format("%04x", it.productId)})" }) { dialogInterface, i ->
                 val permissionIntent = PendingIntent.getBroadcast(activity, 0, Intent(ACTION_USB_PERMISSION), 0)
                 manager.requestPermission(deviceList[i], permissionIntent)
             }

--- a/pretixprint/app/src/main/res/layout/fragment_brotherraster_settings.xml
+++ b/pretixprint/app/src/main/res/layout/fragment_brotherraster_settings.xml
@@ -66,6 +66,18 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tilLabel" />
 
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/swQuality"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/field_label_quality"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/swRotate90" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/pretixprint/app/src/main/res/layout/fragment_brotherraster_settings.xml
+++ b/pretixprint/app/src/main/res/layout/fragment_brotherraster_settings.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:id="@+id/scroll"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fadeScrollbars="false"
+        app:layout_constraintBottom_toTopOf="@id/btnNext"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/textView5"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/setup_protocol_settings"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilLabel"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/textView5"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
+
+                <AutoCompleteTextView
+                    android:id="@+id/teLabel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/field_label_label"
+                    android:inputType="none" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+
+            <com.google.android.material.switchmaterial.SwitchMaterial
+                android:id="@+id/swRotate90"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/field_label_rotate90"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tilLabel" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilWaitAfterPage"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/swRotate90">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/teWaitAfterPage"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/field_label_waitafterpage"
+                    android:inputType="number" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+
+    <Button
+        android:id="@+id/btnNext"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/btn_next"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/scroll"
+        app:layout_constraintVertical_bias="1.0" />
+
+    <Button
+        android:id="@+id/btnPrev"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/btn_prev"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/btnNext"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/scroll"
+        app:layout_constraintVertical_bias="1.0" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/pretixprint/app/src/main/res/layout/fragment_brotherraster_settings.xml
+++ b/pretixprint/app/src/main/res/layout/fragment_brotherraster_settings.xml
@@ -66,24 +66,6 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/tilLabel" />
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/tilWaitAfterPage"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="16dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/swRotate90">
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/teWaitAfterPage"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:hint="@string/field_label_waitafterpage"
-                    android:inputType="number" />
-            </com.google.android.material.textfield.TextInputLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </ScrollView>
 

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -115,4 +115,6 @@
     <string name="field_label_card_destination">Kartenausgabe</string>
     <string name="field_label_label">Papiergröße</string>
     <string name="field_label_quality">Druckqualität erhöhen (etwas langsamer)</string>
+    <string name="label_two_color">rot/schwarz</string>
+    <string name="label_continuous">endlos</string>
 </resources>

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -99,6 +99,7 @@
     <string name="btn_prev">ZURÜCK</string>
     <string name="protocol_fgl">FGL-Ticketdrucker (z.B. Boca, Practical Automation, …)</string>
     <string name="protocol_slcs">SLCS-Etikettendrucker (z.B. Bixolon, Metapace, …)</string>
+    <string name="protocol_brother">Brother-Etikettendrucker</string>
     <string name="protocol_escpos">ESC/POS-Bondrucker (z.B. Epson, Bixolon, …)</string>
     <string name="protocol_linkoscard">Zebra-Kartendrucker (Zebra ZMotif und ZXP Protokoll Kartendrucker; bspw. ZC- und ZXP-Serie)</string>
     <string name="protocol_linkos">Zebra-Thermodrucker (Protkolle CPCL und ZPL)</string>
@@ -112,4 +113,5 @@
     <string name="field_label_print_double_sided">Motiv beidseitig drucken (gleiches Motiv auf beiden Seiten)</string>
     <string name="field_label_card_source">Karteneingabe</string>
     <string name="field_label_card_destination">Kartenausgabe</string>
+    <string name="field_label_label">Papiergröße</string>
 </resources>

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -99,7 +99,7 @@
     <string name="btn_prev">ZURÜCK</string>
     <string name="protocol_fgl">FGL-Ticketdrucker (z.B. Boca, Practical Automation, …)</string>
     <string name="protocol_slcs">SLCS-Etikettendrucker (z.B. Bixolon, Metapace, …)</string>
-    <string name="protocol_brother">Brother-Etikettendrucker</string>
+    <string name="protocol_brother">Brother-Etikettendrucker (QL-Serie)</string>
     <string name="protocol_escpos">ESC/POS-Bondrucker (z.B. Epson, Bixolon, …)</string>
     <string name="protocol_linkoscard">Zebra-Kartendrucker (Zebra ZMotif und ZXP Protokoll Kartendrucker; bspw. ZC- und ZXP-Serie)</string>
     <string name="protocol_linkos">Zebra-Thermodrucker (Protkolle CPCL und ZPL)</string>
@@ -114,4 +114,5 @@
     <string name="field_label_card_source">Karteneingabe</string>
     <string name="field_label_card_destination">Kartenausgabe</string>
     <string name="field_label_label">Papiergröße</string>
+    <string name="field_label_quality">Druckqualität erhöhen (etwas langsamer)</string>
 </resources>

--- a/pretixprint/app/src/main/res/values/strings.xml
+++ b/pretixprint/app/src/main/res/values/strings.xml
@@ -113,4 +113,6 @@
     <string name="field_label_card_destination">Card Destination</string>
     <string name="field_label_label">Label size</string>
     <string name="field_label_quality">Priority given to print quality (a bit slower)</string>
+    <string name="label_two_color">red/black</string>
+    <string name="label_continuous">continuous</string>
 </resources>

--- a/pretixprint/app/src/main/res/values/strings.xml
+++ b/pretixprint/app/src/main/res/values/strings.xml
@@ -97,6 +97,7 @@
     <string name="btn_prev">PREVIOUS</string>
     <string name="protocol_fgl">FGL ticket printer (e.g. Boca, Practical Automation, …)</string>
     <string name="protocol_slcs">SLCS label printer (e.g. Bixolon, Metapace, …)</string>
+    <string name="protocol_brother">Brother label printer</string>
     <string name="protocol_escpos">ESC/POS receipt printer (e.g. Epson, Bixolon, …)</string>
     <string name="protocol_linkoscard">Zebra card printer (ZMotif and ZXP protocol card printers; e.g. ZC- and ZXP-series)</string>
     <string name="protocol_linkos">Zebra thermal printer (CPCL and ZPL protocol)</string>
@@ -110,4 +111,5 @@
     <string name="field_label_print_double_sided">Print double sided (same image on both sides)</string>
     <string name="field_label_card_source">Card Source</string>
     <string name="field_label_card_destination">Card Destination</string>
+    <string name="field_label_label">Label size</string>
 </resources>

--- a/pretixprint/app/src/main/res/values/strings.xml
+++ b/pretixprint/app/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     <string name="btn_prev">PREVIOUS</string>
     <string name="protocol_fgl">FGL ticket printer (e.g. Boca, Practical Automation, …)</string>
     <string name="protocol_slcs">SLCS label printer (e.g. Bixolon, Metapace, …)</string>
-    <string name="protocol_brother">Brother label printer</string>
+    <string name="protocol_brother">Brother label printer (QL series)</string>
     <string name="protocol_escpos">ESC/POS receipt printer (e.g. Epson, Bixolon, …)</string>
     <string name="protocol_linkoscard">Zebra card printer (ZMotif and ZXP protocol card printers; e.g. ZC- and ZXP-series)</string>
     <string name="protocol_linkos">Zebra thermal printer (CPCL and ZPL protocol)</string>
@@ -112,4 +112,5 @@
     <string name="field_label_card_source">Card Source</string>
     <string name="field_label_card_destination">Card Destination</string>
     <string name="field_label_label">Label size</string>
+    <string name="field_label_quality">Priority given to print quality (a bit slower)</string>
 </resources>


### PR DESCRIPTION
This PR adds support for printing with a Brother label printer (tested with a QL-810W) using [Brothers own raster protocol](https://download.brother.com/welcome/docp100278/cv_ql800_eng_raster_100.pdf).
Continuous label paper (sticky or non-sticky) as well as single labels are tested.

In the setup step the currently inserted label size must be chosen from [a list maintained in the source](https://github.com/pretix/pretixprint-android/blob/517a4783ddb4640ff3f3701261832122e39bc1ac/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt#L24-L58):

![brother-settings](https://user-images.githubusercontent.com/172415/156367314-363e261c-a976-49e7-a3b1-50441f39ea77.png)

Contents to be printed are resized to the current chosen label size.

Currently only basic black & white support for red/black labels exists, so users that have red/black label paper inserted can still use it when printing with other software.

Tested with:
- Brother QL-810W over WiFi
- DK-N55224 54mm continuous non-sticky paper
- DK-11201 29mm × 90mm address label
- DK-22205 62mm continuous sticky label paper
- DK-22251 62mm continuous red/black sticky label paper

Future tasks:
- [ ] full support for red/black label paper & contents
- [ ] try to get current label size (in the setup step) by asking printer over SNMP
- [x] check if connection over usb is possible
