### PR TITLE
USB: fix queued packet length and chunk if too large

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
@@ -151,7 +151,7 @@ class UsbOutputStream(usbManager: UsbManager, usbDevice: UsbDevice, val compat: 
             val usbRequest = UsbRequest()
             try {
                 usbRequest.initialize(usbConnection, usbEndpoint)
-                if (!usbRequest.queue(buffer, bytes.size)) {
+                if (!usbRequest.queue(buffer, length)) {
                     throw IOException("Error queueing USB request.")
                 }
                 usbConnection!!.requestWait()


### PR DESCRIPTION
The queued usb request size didn't match, if the offset parameter was used.

Additionally, from https://developer.android.com/reference/android/hardware/usb/UsbRequest#queue(java.nio.ByteBuffer,%20int):
> Before [Build.VERSION_CODES.P](https://developer.android.com/reference/android/os/Build.VERSION_CODES#P) (Android 9), a value larger than 16384 bytes would be truncated down to 16384.
> In API [Build.VERSION_CODES.P](https://developer.android.com/reference/android/os/Build.VERSION_CODES#P) and after, any value of length is valid.

As data is silently discarded here, let's just chunk the data ourselves.

This appeared while testing https://github.com/pretix/pretixprint-android/pull/20, so we should check this thoroughly with all our currently supported usb printers before merging.