### PR TITLE
Upgrade sentry

### DIFF
--- a/pretixprint/app/build.gradle
+++ b/pretixprint/app/build.gradle
@@ -43,25 +43,24 @@ android {
             properties.load(project.rootProject.file('local.properties').newDataInputStream())
             sentry_dsn = properties.getProperty('sentry.dsn')
             if (sentry_dsn == null) {
-                sentry_dsn = "null"
-            } else {
-                sentry_dsn = "\"" + sentry_dsn + "\""
+                sentry_dsn = ""
             }
         } catch (all) {
-            sentry_dsn = "null"
+            sentry_dsn = ""
         }
 
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            multiDexKeepProguard file('multidex-config.pro')
             signingConfig signingConfigs.release
-            buildConfigField "String", "SENTRY_DSN", sentry_dsn
+            manifestPlaceholders["SENTRY_DSN"] = sentry_dsn
         }
         debug {
             debuggable true
             applicationIdSuffix ".debug"
             versionNameSuffix "-debug"
-            buildConfigField "String", "SENTRY_DSN", "null"
+            manifestPlaceholders["SENTRY_DSN"] = ""
         }
     }
 
@@ -115,7 +114,7 @@ dependencies {
     implementation 'com.google.zxing:core:3.3.3'
 
     implementation 'joda-time:joda-time:2.10.10'
-    implementation 'io.sentry:sentry-android:1.7.29'
+    implementation 'io.sentry:sentry-android:5.7.0'
     implementation 'org.slf4j:slf4j-nop:1.7.30'
 
     implementation 'com.facebook.stetho:stetho:1.5.1'

--- a/pretixprint/app/multidex-config.pro
+++ b/pretixprint/app/multidex-config.pro
@@ -1,0 +1,3 @@
+# See https://docs.sentry.io/platforms/android/configuration/multi-dex/
+-keep class io.sentry.android.core.SentryAndroidOptions
+-keep class io.sentry.android.ndk.SentryNdk

--- a/pretixprint/app/src/main/AndroidManifest.xml
+++ b/pretixprint/app/src/main/AndroidManifest.xml
@@ -90,6 +90,8 @@
                 <action android:name="eu.pretix.pretixpos.print.PRINT_RECEIPT" />
             </intent-filter>
         </service>
+
+        <meta-data android:name="io.sentry.dsn" android:value="${SENTRY_DSN}" />
     </application>
 
 </manifest>

--- a/pretixprint/app/src/main/AndroidManifest.xml
+++ b/pretixprint/app/src/main/AndroidManifest.xml
@@ -92,6 +92,12 @@
         </service>
 
         <meta-data android:name="io.sentry.dsn" android:value="${SENTRY_DSN}" />
+        <meta-data android:name="io.sentry.auto-session-tracking.enable" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.activity-lifecycle" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.app-lifecycle" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.system-events" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.app-components" android:value="false" />
+        <meta-data android:name="io.sentry.breadcrumbs.user-interaction" android:value="false" />
     </application>
 
 </manifest>

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/PretixPrint.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/PretixPrint.kt
@@ -4,8 +4,6 @@ import androidx.multidex.MultiDexApplication
 import com.facebook.stetho.Stetho
 import com.tom_roush.pdfbox.util.PDFBoxResourceLoader
 import eu.pretix.pretixprint.print.WYSIWYGRenderer
-import io.sentry.Sentry
-import io.sentry.android.AndroidSentryClientFactory
 
 class PretixPrint : MultiDexApplication() {
     override fun onCreate() {
@@ -13,10 +11,6 @@ class PretixPrint : MultiDexApplication() {
 
         if (BuildConfig.DEBUG) {
             Stetho.initializeWithDefaults(this)
-        }
-        if (BuildConfig.SENTRY_DSN != null) {
-            val sentryDsn = BuildConfig.SENTRY_DSN
-            Sentry.init(sentryDsn, AndroidSentryClientFactory(this))
         }
         WYSIWYGRenderer.registerFonts(this)
         PDFBoxResourceLoader.init(getApplicationContext());

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/CUPS.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/CUPS.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import eu.pretix.pretixprint.PrintException
 import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.print.getPrinter
+import io.sentry.Sentry
 import org.cups4j.CupsPrinter
 import org.cups4j.PrintJob
 import org.jetbrains.anko.defaultSharedPreferences
@@ -29,6 +30,14 @@ class CUPSConnection : ConnectionType {
         val serverAddr = getSetting("hardware_${type}printer_ip", "127.0.0.1")
         val port = getSetting("hardware_${type}printer_port", "631")
         val name = getSetting("hardware_${type}printer_printername", "Test")
+
+        Sentry.configureScope { scope ->
+            scope.setTag("printer.type", type)
+            scope.setContexts("printer.ip", serverAddr)
+            scope.setContexts("printer.port", port)
+            scope.setContexts("printer.printername", name)
+        }
+
         var cp: CupsPrinter? = null
         try {
             cp = getPrinter(

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/PrintService.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/PrintService.kt
@@ -77,7 +77,7 @@ abstract class AbstractPrintService(name: String) : IntentService(name) {
             pw.flush()
             fw.close()
         } catch (ee: Throwable) {
-            Sentry.capture(ee)
+            Sentry.captureException(ee)
             ee.printStackTrace()
         }
     }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/PrintService.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/PrintService.kt
@@ -94,6 +94,13 @@ abstract class AbstractPrintService(name: String) : IntentService(name) {
         val connection = prefs.getString("hardware_${type}printer_connection", "network_printer")
         val mode = prefs.getString("hardware_${type}printer_mode", "")
 
+        Sentry.configureScope { scope ->
+            scope.setTag("type", type)
+            scope.setTag("renderer", renderer)
+            scope.setTag("connection", connection!!)
+            scope.setTag("printer.mode", mode!!)
+        }
+
         val pages = emptyList<CompletableFuture<File?>>().toMutableList()
         var tmpfile: File?
         var pagenum = 0

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/FinishSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/FinishSettingsFragment.kt
@@ -70,7 +70,7 @@ class FinishSettingsFragment : SetupFragment() {
                     }
                 } catch (e: java.lang.Exception) {
                     e.printStackTrace()
-                    Sentry.capture(e)
+                    Sentry.captureException(e)
                     uiThread {
                         if (this@FinishSettingsFragment.activity == null)
                             return@uiThread

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/FinishSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/FinishSettingsFragment.kt
@@ -63,6 +63,7 @@ class FinishSettingsFragment : SetupFragment() {
                         alert(R.string.test_success).show()
                     }
                 } catch (e: PrintException) {
+                    Sentry.captureException(e)
                     uiThread {
                         if (this@FinishSettingsFragment.activity == null)
                             return@uiThread
@@ -106,6 +107,10 @@ class FinishSettingsFragment : SetupFragment() {
         val proto = getProtoClass(activity.proto())
 
         val file = writeDemoPage(proto.demopage)
+
+        Sentry.configureScope { scope ->
+            scope.setTag("printer.test", "true")
+        }
 
         when (activity.mode()) {
             NetworkConnection().identifier -> {

--- a/pretixprint/build.gradle
+++ b/pretixprint/build.gradle
@@ -12,7 +12,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'io.sentry:sentry-android-gradle-plugin:1.7.36'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -21,6 +20,7 @@ buildscript {
 
 plugins {
     id "com.jaredsburrows.license" version "0.8.90"
+    id "io.sentry.android.gradle" version "3.0.0"
 }
 
 allprojects {


### PR DESCRIPTION
Bump sentry to the current version. Disable some of the new session and breadcrumb-features that are default enabled but we don't need. Add some tagging/context to the print operations, so if something fails there, the error's more useful by providing details about the used connection, protocol etc.