### PR TITLE
Lock identical printers used for two use cases

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/Interface.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/Interface.kt
@@ -10,7 +10,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
 
-interface ByteProtocolInterface<T> {
+sealed interface ByteProtocolInterface<T> {
     val identifier: String
     val nameResource: Int
     val defaultDPI: Int

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Network.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Network.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import eu.pretix.pretixprint.PrintException
 import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.byteprotocols.*
+import eu.pretix.pretixprint.print.lockManager
 import eu.pretix.pretixprint.renderers.renderPages
 import io.sentry.Sentry
 import org.jetbrains.anko.defaultSharedPreferences
@@ -53,28 +54,30 @@ class NetworkConnection : ConnectionType {
         try {
             Log.i("PrintService", "Starting renderPages")
             val futures = renderPages(proto, tmpfile, dpi, numPages, conf, type)
-            when (proto) {
-                is StreamByteProtocol<*> -> {
-                    Log.i("PrintService", "Start connection to ${serverAddr.hostAddress}:$port")
-                    val socket = Socket(serverAddr, port)
-                    val ostream = socket.getOutputStream()
-                    val istream = socket.getInputStream()
+            lockManager.withLock("$identifier:${serverAddr.hostAddress}:$port") {
+                when (proto) {
+                    is StreamByteProtocol<*> -> {
+                        Log.i("PrintService", "Start connection to ${serverAddr.hostAddress}:$port")
+                        val socket = Socket(serverAddr, port)
+                        val ostream = socket.getOutputStream()
+                        val istream = socket.getInputStream()
 
-                    try {
-                        Log.i("PrintService", "Start proto.send()")
-                        proto.send(futures, istream, ostream, conf, type)
-                        Log.i("PrintService", "Finished proto.send()")
-                    } finally {
-                        istream.close()
-                        ostream.close()
-                        socket.close()
+                        try {
+                            Log.i("PrintService", "Start proto.send()")
+                            proto.send(futures, istream, ostream, conf, type)
+                            Log.i("PrintService", "Finished proto.send()")
+                        } finally {
+                            istream.close()
+                            ostream.close()
+                            socket.close()
+                        }
                     }
-                }
 
-                is CustomByteProtocol<*> -> {
-                    Log.i("PrintService", "Start proto.sendNetwork()")
-                    proto.sendNetwork(serverAddr.hostAddress, port, futures, conf, type, context)
-                    Log.i("PrintService", "Finished proto.sendNetwork()")
+                    is CustomByteProtocol<*> -> {
+                        Log.i("PrintService", "Start proto.sendNetwork()")
+                        proto.sendNetwork(serverAddr.hostAddress, port, futures, conf, type, context)
+                        Log.i("PrintService", "Finished proto.sendNetwork()")
+                    }
                 }
             }
         } catch (e: TimeoutException) {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/Lock.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/Lock.kt
@@ -1,0 +1,19 @@
+package eu.pretix.pretixprint.print
+
+import java.util.concurrent.locks.ReentrantLock
+import kotlin.concurrent.withLock
+
+
+class LockManager() {
+    private val lockMap = mutableMapOf<String, ReentrantLock>()
+
+    fun <T> withLock(name: String, action: (() -> T)) {
+        val lock = lockMap.getOrPut(name) { ReentrantLock() }
+        lock.withLock {
+            action()
+        }
+    }
+}
+
+
+val lockManager = LockManager()


### PR DESCRIPTION
This might help with some issues where the same USB printer is used twice at the same time. Not sure though since I can't reproduce the issues. Can you check if this makes anything better eg with the bluetooth issues, @robbi5?