### PR TITLE
Early exit when chosen printer connection is unconfigured

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Interface.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Interface.kt
@@ -1,7 +1,7 @@
 package eu.pretix.pretixprint.connections
 
 import android.content.Context
-import android.text.InputType
+import org.jetbrains.anko.defaultSharedPreferences
 import java.io.File
 
 interface ConnectionType {
@@ -16,4 +16,8 @@ interface ConnectionType {
 
     fun allowedForUsecase(type: String): Boolean
     fun print(tmpfile: File, numPages: Int, context: Context, useCase: String, settings: Map<String, String>? = null)
+
+    fun isConfiguredFor(context: Context, type: String): Boolean {
+        return !context.defaultSharedPreferences.getString("hardware_${type}printer_ip", "").isNullOrEmpty()
+    }
 }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/System.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/System.kt
@@ -23,6 +23,10 @@ class SystemConnection : ConnectionType {
         return type != "receipt"
     }
 
+    override fun isConfiguredFor(context: Context, type: String): Boolean {
+        return true
+    }
+
     override fun print(
         tmpfile: File,
         numPages: Int,


### PR DESCRIPTION
Until now, trying to print on an unconfigured printer type succeeds quite a bit, the layout gets rendered etc. Only shortly before the actual printing an error message appears, but it does not indicate that no printer is configured.
This PR moves the connection type selection to the start and checks if it is configured - if not, it exits with an `Printer is not configured for type $type"` exception