### PR TITLE
Skip rendering of null text content

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/WYSIWYGRenderer.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/WYSIWYGRenderer.kt
@@ -53,6 +53,9 @@ class OrderPositionContentProvider(private val order: JSONObject, private val op
         } else if (content == "other_i18n") {
             return if (textI18n != null) interpolate(i18nToString(textI18n) ?: "") else ""
         } else if (op.has("pdf_data") && op.getJSONObject("pdf_data").has(content)) {
+            if (op.getJSONObject("pdf_data").isNull(content)) {
+                return ""
+            }
             return op.getJSONObject("pdf_data").getString(content)
         } else {
             return "???"


### PR DESCRIPTION
This happened sometimes with the attendee_* pdf data, which resulted in visible "null" on the ticket printout.