### PR TITLE
Add PIN for printer settings

### DIFF
--- a/pretixprint/app/build.gradle
+++ b/pretixprint/app/build.gradle
@@ -110,6 +110,7 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'com.tom_roush:pdfbox-android:1.8.10.0'
     implementation "androidx.viewpager2:viewpager2:1.0.0"
+    implementation 'com.andrognito.pinlockview:pinlockview:2.1.0'
 
     // libpretixprint
     implementation 'com.github.librepdf:openpdf:1.3.24'

--- a/pretixprint/app/src/main/AndroidManifest.xml
+++ b/pretixprint/app/src/main/AndroidManifest.xml
@@ -27,6 +27,11 @@
         android:logo="@drawable/ic_logo"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
+
+        <meta-data
+            android:name="android.content.APP_RESTRICTIONS"
+            android:resource="@xml/app_restrictions" />
+
         <activity
             android:name=".ui.SystemPrintActivity"
             android:exported="false"

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/PrinterSetupActivity.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/PrinterSetupActivity.kt
@@ -30,6 +30,15 @@ class PrinterSetupActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_printer_setup)
+
+        if (!defaultSharedPreferences.getString("pref_pin", "").isNullOrBlank() &&
+            (!intent.hasExtra("pin") ||
+                defaultSharedPreferences.getString("pref_pin", "") != intent.getStringExtra("pin")!!)) {
+            // Protect against external calls
+            finish();
+            return
+        }
+
         useCase = intent.extras?.getString(EXTRA_USECASE) ?: ""
         startConnectionChoice()
     }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/ProtectedEditTextPreference.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/ProtectedEditTextPreference.kt
@@ -1,0 +1,27 @@
+package eu.pretix.pretixprint.ui
+
+import android.content.Context
+import android.preference.EditTextPreference
+import android.util.AttributeSet
+
+class ProtectedEditTextPreference(context: Context, attrs: AttributeSet) :
+    EditTextPreference(context, attrs) {
+
+    var earlyClickListener: OnPreferenceClickListener? = null
+
+    fun setEarlyPreferenceClickListener(onPreferenceClickListener: OnPreferenceClickListener) {
+        earlyClickListener = onPreferenceClickListener
+    }
+
+    override fun onClick() {
+        if (earlyClickListener != null && earlyClickListener!!.onPreferenceClick(this)) {
+            return
+        }
+
+        super.onClick()
+    }
+
+    fun showDialog() {
+        super.showDialog(null)
+    }
+}

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/ProtectedListPreference.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/ProtectedListPreference.kt
@@ -1,0 +1,27 @@
+package eu.pretix.pretixprint.ui
+
+import android.content.Context
+import android.preference.ListPreference
+import android.util.AttributeSet
+
+class ProtectedListPreference(context: Context, attrs: AttributeSet):
+    ListPreference(context, attrs) {
+
+    var earlyClickListener: OnPreferenceClickListener? = null
+
+    fun setEarlyPreferenceClickListener(onPreferenceClickListener: OnPreferenceClickListener) {
+        earlyClickListener = onPreferenceClickListener
+    }
+
+    override fun onClick() {
+        if (earlyClickListener != null && earlyClickListener!!.onPreferenceClick(this)) {
+            return
+        }
+
+        super.onClick()
+    }
+
+    fun showDialog() {
+        super.showDialog(null)
+    }
+}

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/Settings.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/Settings.kt
@@ -1,6 +1,10 @@
 package eu.pretix.pretixprint.ui
 
+import android.annotation.TargetApi
+import android.content.Context
 import android.content.Intent
+import android.content.RestrictionsManager
+import android.os.Build
 import android.os.Bundle
 import android.preference.ListPreference
 import android.preference.PreferenceFragment
@@ -224,7 +228,7 @@ class SettingsActivity : AppCompatPreferenceActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
+        applyRestrictions(this)
         if (!defaultSharedPreferences.contains("first_start")) {
             defaultSharedPreferences.edit().putBoolean("first_start", true).apply();
             val intent = Intent(this, WelcomeActivity::class.java)
@@ -237,5 +241,18 @@ class SettingsActivity : AppCompatPreferenceActivity() {
         fragmentManager.beginTransaction()
                 .replace(android.R.id.content, SettingsFragment())
                 .commit()
+    }
+
+    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+    fun applyRestrictions(ctx: Context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return
+        }
+        val restrictionsMgr = ctx.getSystemService(Context.RESTRICTIONS_SERVICE) as RestrictionsManager?
+            ?: return
+        val restrictions = restrictionsMgr.applicationRestrictions
+        if (restrictions.containsKey("pref_pin")) {
+            defaultSharedPreferences.edit().putString("pref_pin", restrictions.getString("pref_pin")).apply()
+        }
     }
 }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/Settings.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/Settings.kt
@@ -9,6 +9,10 @@ import android.view.LayoutInflater
 import android.webkit.WebView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import com.andrognito.pinlockview.IndicatorDots
+import com.andrognito.pinlockview.PinLockListener
+import com.andrognito.pinlockview.PinLockView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import eu.pretix.pretixprint.BuildConfig
 import eu.pretix.pretixprint.R
 import org.jetbrains.anko.defaultSharedPreferences
@@ -33,7 +37,7 @@ class SettingsFragment : PreferenceFragment() {
             findPreference("hardware_${type}printer_find").setOnPreferenceClickListener {
                 val intent = Intent(activity, PrinterSetupActivity::class.java)
                 intent.putExtra(PrinterSetupActivity.EXTRA_USECASE, type)
-                activity.startActivity(intent)
+                startWithPIN(intent)
                 return@setOnPreferenceClickListener true
             }
         }
@@ -52,6 +56,29 @@ class SettingsFragment : PreferenceFragment() {
         findPreference("licenses").setOnPreferenceClickListener {
             asset_dialog(R.string.settings_label_licenses)
             return@setOnPreferenceClickListener true
+        }
+
+        (findPreference("hardware_receiptprinter_cpl") as ProtectedListPreference).setEarlyPreferenceClickListener { pref ->
+            if (!hasPin()) {
+                // false: handle normally
+                return@setEarlyPreferenceClickListener false
+            }
+            pinProtect {
+                (pref as ProtectedListPreference).showDialog()
+            }
+            // true: we've handled it, skip
+            return@setEarlyPreferenceClickListener true
+        }
+
+        (findPreference("pref_pin") as ProtectedEditTextPreference).setEarlyPreferenceClickListener { pref ->
+            if (!hasPin()) {
+                // false: handle normally
+                return@setEarlyPreferenceClickListener false
+            }
+            pinProtect {
+                (pref as ProtectedEditTextPreference).showDialog()
+            }
+            return@setEarlyPreferenceClickListener true
         }
 
         findPreference("version").summary = BuildConfig.VERSION_NAME
@@ -137,6 +164,58 @@ class SettingsFragment : PreferenceFragment() {
                 else -> throw RuntimeException("Unknown file type for file $file")
             }
 
+        }
+    }
+
+    fun hasPin(): Boolean {
+        return !defaultSharedPreferences.getString("pref_pin", "").isNullOrBlank()
+    }
+
+    fun pinProtect(valid: ((pin: String) -> Unit)) {
+        if (!hasPin()) {
+            valid("")
+            return
+        }
+        val pinLength = defaultSharedPreferences.getString("pref_pin", "")!!.length
+        val view = activity.layoutInflater.inflate(R.layout.dialog_pin, null)
+        val dialog = MaterialAlertDialogBuilder(activity)
+            .setView(view)
+            .create()
+        dialog.setOnShowListener {
+            val mPinLockListener: PinLockListener = object : PinLockListener {
+                override fun onComplete(pin: String) {
+                    this.onPinChange(pin.length, pin)
+                }
+
+                override fun onEmpty() {
+                }
+
+                override fun onPinChange(pinLength: Int, intermediatePin: String) {
+                    if (defaultSharedPreferences.getString("pref_pin", "") == intermediatePin) {
+                        dialog.dismiss()
+                        valid(intermediatePin)
+                    }
+                }
+            }
+
+            val lockView = view.findViewById(R.id.pin_lock_view) as PinLockView
+            lockView.pinLength = pinLength
+            lockView.setPinLockListener(mPinLockListener)
+            val idots = view.findViewById(R.id.indicator_dots) as IndicatorDots
+            idots.pinLength = pinLength
+            lockView.attachIndicatorDots(idots);
+        }
+        dialog.show()
+    }
+
+    fun startWithPIN(intent: Intent, resultCode: Int? = null, bundle: Bundle? = null) {
+        pinProtect { pin ->
+            intent.putExtra("pin", pin)
+            if (resultCode != null) {
+                startActivityForResult(intent, resultCode, bundle)
+            } else {
+                startActivity(intent)
+            }
         }
     }
 }

--- a/pretixprint/app/src/main/res/layout/dialog_pin.xml
+++ b/pretixprint/app/src/main/res/layout/dialog_pin.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="0dp"
+    android:layout_weight="1">
+
+    <com.andrognito.pinlockview.IndicatorDots
+        android:id="@+id/indicator_dots"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        app:dotEmptyBackground="@color/pretix_brand_lightgrey"
+        app:dotFilledBackground="@color/pretix_brand_dark"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.andrognito.pinlockview.PinLockView
+        android:id="@+id/pin_lock_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        app:keypadTextColor="@color/pretix_brand_dark"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/indicator_dots" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -131,4 +131,5 @@
     <string name="label_continuous">endlos</string>
     <string name="print_now_notification">Druck bereit. Antippen um Druckdialog zu öffnen.</string>
     <string name="pin_protection_pin">Einstellungen-PIN setzen</string>
+    <string name="pin_protection_description">Einstellungen mit einer selbstgewählten PIN sperren, die zum Ändern der Drucker-Konfiguration eingegeben werden muss</string>
 </resources>

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -17,6 +17,7 @@
     <string name="settings_label_port">Port</string>
     <string name="settings_label_printername">Druckername</string>
     <string name="settings_label_driver">Drucker</string>
+    <string name="settings_label_security">Sicherheit</string>
     <string name="notification_channel_print">Druckjobs</string>
     <string name="notification_channel_print_description">Zeigt eine Benachrichtigung, während gedruckt wird.</string>
     <string name="print_notification">Drucke…</string>
@@ -129,4 +130,5 @@
     <string name="label_two_color">rot/schwarz</string>
     <string name="label_continuous">endlos</string>
     <string name="print_now_notification">Druck bereit. Antippen um Druckdialog zu öffnen.</string>
+    <string name="pin_protection_pin">Einstellungen-PIN setzen</string>
 </resources>

--- a/pretixprint/app/src/main/res/values/strings.xml
+++ b/pretixprint/app/src/main/res/values/strings.xml
@@ -130,4 +130,5 @@
     <string name="label_two_color">red/black</string>
     <string name="label_continuous">continuous</string>
     <string name="pin_protection_pin">Set settings PIN</string>
+    <string name="pin_protection_description">Lock settings with a custom PIN that must be entered if you want to change printer configuration</string>
 </resources>

--- a/pretixprint/app/src/main/res/values/strings.xml
+++ b/pretixprint/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="settings_label_port">Port</string>
     <string name="settings_label_printername">Printer name</string>
     <string name="settings_label_driver">Driver</string>
+    <string name="settings_label_security">Security</string>
     <string name="dismiss">Close</string>
     <string name="notification_channel_print">Print jobs</string>
     <string name="notification_channel_print_description">Shows a notification during a print job</string>
@@ -128,4 +129,5 @@
     <string name="field_label_quality">Priority given to print quality (a bit slower)</string>
     <string name="label_two_color">red/black</string>
     <string name="label_continuous">continuous</string>
+    <string name="pin_protection_pin">Set settings PIN</string>
 </resources>

--- a/pretixprint/app/src/main/res/xml/app_restrictions.xml
+++ b/pretixprint/app/src/main/res/xml/app_restrictions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<restrictions xmlns:android="http://schemas.android.com/apk/res/android">
+    <restriction
+        android:defaultValue=""
+        android:key="pref_pin"
+        android:restrictionType="string"
+        android:title="@string/pin_protection_pin" />
+</restrictions>

--- a/pretixprint/app/src/main/res/xml/app_restrictions.xml
+++ b/pretixprint/app/src/main/res/xml/app_restrictions.xml
@@ -4,5 +4,6 @@
         android:defaultValue=""
         android:key="pref_pin"
         android:restrictionType="string"
-        android:title="@string/pin_protection_pin" />
+        android:title="@string/pin_protection_pin"
+        android:description="@string/pin_protection_description" />
 </restrictions>

--- a/pretixprint/app/src/main/res/xml/preferences.xml
+++ b/pretixprint/app/src/main/res/xml/preferences.xml
@@ -19,7 +19,7 @@
 
     <PreferenceCategory android:title="@string/settings_label_receiptprinter">
         <Preference android:key="hardware_receiptprinter_find" android:title="@string/settings_label_find"/>
-        <ListPreference
+        <eu.pretix.pretixprint.ui.ProtectedListPreference
             android:entries="@array/receipt_width"
             android:entryValues="@array/receipt_cpl"
             android:key="hardware_receiptprinter_cpl"
@@ -31,6 +31,13 @@
             android:key="last_prints"
             android:title="@string/settings_label_last_prints"
             />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/settings_label_security">
+        <eu.pretix.pretixprint.ui.ProtectedEditTextPreference
+            android:inputType="number"
+            android:key="pref_pin"
+            android:title="@string/pin_protection_pin" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_label_about">

--- a/pretixprint/app/src/main/res/xml/preferences.xml
+++ b/pretixprint/app/src/main/res/xml/preferences.xml
@@ -37,7 +37,8 @@
         <eu.pretix.pretixprint.ui.ProtectedEditTextPreference
             android:inputType="number"
             android:key="pref_pin"
-            android:title="@string/pin_protection_pin" />
+            android:title="@string/pin_protection_pin"
+            android:summary="@string/pin_protection_description" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_label_about">


### PR DESCRIPTION
For customer site installations, where the POS/printer end-users shouldn't change printer settings themselves.

Built for and with the old `android.preferences` apis. Needs to be converted to `androidx.preferences`, when we migrate to it.