### PR TITLE
Fixed wrong import

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/StarPRNT.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/StarPRNT.kt
@@ -1,7 +1,7 @@
 package eu.pretix.pretixprint.byteprotocols
 
-import com.zebra.sdk.comm.BluetoothConnection
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.BluetoothConnection
 import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.connections.NetworkConnection
 import eu.pretix.pretixprint.connections.USBConnection


### PR DESCRIPTION
Corrected wrong import in StarPRNT.kt:
Now uses eu.pretix.pretixprint.connections.BluetoothConnection instead of import com.zebra.sdk.comm.BluetoothConnection