### PR TITLE
Fixed wrong casting that could result in crash

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/StarPRNT.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/StarPRNT.kt
@@ -1,7 +1,7 @@
 package eu.pretix.pretixprint.byteprotocols
 
-import com.zebra.sdk.comm.BluetoothConnection
 import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.BluetoothConnection
 import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.connections.NetworkConnection
 import eu.pretix.pretixprint.connections.USBConnection

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BrotherRasterSettingsFragment.kt
@@ -9,7 +9,6 @@ import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
 import android.widget.Button
 import com.google.android.material.switchmaterial.SwitchMaterial
-import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
 import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.byteprotocols.BrotherRaster
@@ -71,7 +70,7 @@ class BrotherRasterSettingsFragment : SetupFragment() {
             val quality = view.findViewById<SwitchMaterial>(R.id.swQuality).isChecked
             val rotate90 = view.findViewById<SwitchMaterial>(R.id.swRotate90).isChecked
             if (TextUtils.isEmpty(label)) {
-                view.findViewById<TextInputEditText>(R.id.tilLabel).error = getString(R.string.err_field_required)
+                view.findViewById<TextInputLayout>(R.id.tilLabel).error = getString(R.string.err_field_required)
             } else {
                 val mappedLabel = BrotherRaster.Label.values().find { translatedLabelName(it) == label }!!.name
 


### PR DESCRIPTION
Fixed a wrong casting that could result in a crash, when the label size field was not set to any value, upon pressing the "next" button.