### PR TITLE
Fix missing secret in qr code for old layouts

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/WYSIWYGRenderer.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/WYSIWYGRenderer.kt
@@ -69,6 +69,7 @@ class OrderPositionContentProvider(private val order: JSONObject, private val op
     override fun getBarcodeContent(content: String?, text: String?, textI18n: JSONObject?): String {
         return when (content) {
             "secret" -> op.getString("secret")  // the one in textcontent might be shortened
+            "" -> op.getString("secret")  // required for backwards compatibility
             "pseudonymization_id" -> op.getString("pseudonymization_id")  // required for backwards compatibility
             else -> getTextContent(content, text, textI18n)
         }


### PR DESCRIPTION
We've dropped backwards compatibility for old ticket layouts by accident in #22 - the `barcodearea` element did not always have an `content` property. This PR restores this.