### PR TITLE
Enable Bluetooth connection support for BrotherRaster byteprotocol

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
@@ -7,6 +7,7 @@ import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.connections.NetworkConnection
 import eu.pretix.pretixprint.connections.USBConnection
+import eu.pretix.pretixprint.connections.BluetoothConnection
 import eu.pretix.pretixprint.ui.BrotherRasterSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
@@ -78,7 +79,7 @@ class BrotherRaster : StreamByteProtocol<Bitmap> {
     }
 
     override fun allowedForConnection(type: ConnectionType): Boolean {
-        return type is NetworkConnection || type is USBConnection
+        return type is NetworkConnection || type is USBConnection || type is BluetoothConnection
     }
 
     override fun convertPageToBytes(img: Bitmap, isLastPage: Boolean, previousPage: Bitmap?, conf: Map<String, String>, type: String): ByteArray {


### PR DESCRIPTION
The BrotherRaster byteprotocol also works when connected via Bluetooth. This was tested with a Brother QL-820NWB. With this edit, the "Brother label printer (QL series)" protocol is also shown when configuring a connection via Bluetooth.