### PR TITLE
Raise target SDK to 33

### DIFF
--- a/pretixprint/app/build.gradle
+++ b/pretixprint/app/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.jaredsburrows.license'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "eu.pretix.pretixprint"
         minSdkVersion 19
-        targetSdkVersion 30
+        targetSdkVersion 33
         versionCode 47
         versionName "2.10.1"
         vectorDrawables.useSupportLibrary = true

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOS.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOS.kt
@@ -14,7 +14,7 @@ import com.zebra.sdk.printer.ZebraPrinterFactory
 import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.connections.NetworkConnection
-import eu.pretix.pretixprint.connections.SunmiInternalConnection
+import eu.pretix.pretixprint.connections.BluetoothConnection
 import eu.pretix.pretixprint.connections.USBConnection
 import eu.pretix.pretixprint.ui.LinkOSSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
@@ -21,6 +21,7 @@ import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.connections.NetworkConnection
 import eu.pretix.pretixprint.connections.USBConnection
+import eu.pretix.pretixprint.connections.BluetoothConnection
 import eu.pretix.pretixprint.ui.LinkOSCardSettingsFragment
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture

--- a/pretixprint/app/src/main/AndroidManifest.xml
+++ b/pretixprint/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <queries>
         <package android:name="woyou.aidlservice.jiuiv5"/>  <!-- Sunmi -->

--- a/pretixprint/app/src/main/AndroidManifest.xml
+++ b/pretixprint/app/src/main/AndroidManifest.xml
@@ -3,8 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="eu.pretix.pretixprint">
 
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"  android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />

--- a/pretixprint/app/src/main/AndroidManifest.xml
+++ b/pretixprint/app/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
             android:label="@string/title_activity_fileviewer" />
         <activity
             android:name=".ui.USBAttachedActivity"
+            android:exported="true"
             android:directBootAware="true">
             <intent-filter>
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
@@ -65,6 +66,7 @@
             android:parentActivityName=".ui.SettingsActivity" />
         <activity
             android:name=".ui.SettingsActivity"
+            android:exported="true"
             android:label="@string/title_activity_main">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
@@ -420,7 +420,7 @@ class USBConnection : ConnectionType {
         val filter = IntentFilter(ACTION_USB_PERMISSION)
         context.registerReceiver(recv, filter)
         val permissionIntent = PendingIntent.getBroadcast(context, 0, Intent(ACTION_USB_PERMISSION),
-                if (Build.VERSION.SDK_INT >= 23) { PendingIntent.FLAG_IMMUTABLE } else { 0 })
+                if (Build.VERSION.SDK_INT >= 31) { PendingIntent.FLAG_MUTABLE } else { 0 })
         manager.requestPermission(devices.values.first(), permissionIntent)
         while (!done && err == null && System.currentTimeMillis() - start < 30000) {
             // Wait for callback to be called

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
@@ -419,7 +419,8 @@ class USBConnection : ConnectionType {
 
         val filter = IntentFilter(ACTION_USB_PERMISSION)
         context.registerReceiver(recv, filter)
-        val permissionIntent = PendingIntent.getBroadcast(context, 0, Intent(ACTION_USB_PERMISSION), 0)
+        val permissionIntent = PendingIntent.getBroadcast(context, 0, Intent(ACTION_USB_PERMISSION),
+                if (Build.VERSION.SDK_INT >= 23) { PendingIntent.FLAG_IMMUTABLE } else { 0 })
         manager.requestPermission(devices.values.first(), permissionIntent)
         while (!done && err == null && System.currentTimeMillis() - start < 30000) {
             // Wait for callback to be called

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/PrintService.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/PrintService.kt
@@ -56,7 +56,8 @@ abstract class AbstractPrintService(name: String) : IntentService(name) {
     private fun startForegroundNotification() {
         createNotificationChannel()
         val notificationIntent = Intent(this, SettingsActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0)
+        val pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent,
+                if (Build.VERSION.SDK_INT >= 23) { PendingIntent.FLAG_IMMUTABLE } else { 0 })
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)
                     .setContentTitle(getText(R.string.print_notification))
                     .setContentIntent(pendingIntent)
@@ -248,7 +249,7 @@ abstract class AbstractPrintService(name: String) : IntentService(name) {
             dialogIntent.putExtra(SystemPrintActivity.INTENT_EXTRA_PAGENUM, pagenum)
             dialogIntent.putExtra(SystemPrintActivity.INTENT_EXTRA_TYPE, type)
             val pendingIntent = PendingIntent.getActivity(this, 0, dialogIntent,
-                PendingIntent.FLAG_CANCEL_CURRENT)
+                PendingIntent.FLAG_CANCEL_CURRENT or if (Build.VERSION.SDK_INT >= 23) { PendingIntent.FLAG_IMMUTABLE } else { 0 })
 
             val notification = NotificationCompat.Builder(this, CHANNEL_ID)
                     .setContentTitle(getText(R.string.print_now_notification))

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BluetoothSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/BluetoothSettingsFragment.kt
@@ -1,10 +1,14 @@
 package eu.pretix.pretixprint.ui
 
+import android.Manifest
+import android.annotation.SuppressLint
 import android.bluetooth.BluetoothDevice
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.LayoutInflater
@@ -12,6 +16,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
 import android.widget.TextView
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import com.google.android.material.textfield.TextInputEditText
 import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.ui.BluetoothDeviceManager.BluetoothDevicePickResultHandler
@@ -61,6 +67,22 @@ class BluetoothSettingsFragment : SetupFragment() {
                         mac)
                 (activity as PrinterSetupActivity).startProtocolChoice()
             }
+        }
+
+        val requestPermissionLauncher =
+            registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+                if (!isGranted) {
+                    back()
+                }
+            }
+
+        val perm = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                Manifest.permission.BLUETOOTH_CONNECT
+            } else {
+                Manifest.permission.BLUETOOTH_ADMIN
+            }
+        if (ContextCompat.checkSelfPermission(requireContext(), perm) != PackageManager.PERMISSION_GRANTED) {
+            requestPermissionLauncher.launch(perm)
         }
 
         return view

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/USBSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/USBSettingsFragment.kt
@@ -89,7 +89,7 @@ class USBSettingsFragment : SetupFragment() {
             val deviceList = manager.deviceList.values.toList()
             selector(getString(R.string.headline_found_usb_devices), deviceList.map { "${it.manufacturerName} ${it.productName} (${String.format("%04x", it.vendorId)}:${String.format("%04x", it.productId)})" }) { dialogInterface, i ->
                 val permissionIntent = PendingIntent.getBroadcast(activity, 0, Intent(ACTION_USB_PERMISSION),
-                        if (Build.VERSION.SDK_INT >= 23) { PendingIntent.FLAG_IMMUTABLE } else { 0 })
+                        if (Build.VERSION.SDK_INT >= 31) { PendingIntent.FLAG_MUTABLE } else { 0 })
                 manager.requestPermission(deviceList[i], permissionIntent)
             }
         }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/USBSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/USBSettingsFragment.kt
@@ -88,7 +88,8 @@ class USBSettingsFragment : SetupFragment() {
             val manager = activity!!.getSystemService(Context.USB_SERVICE) as UsbManager
             val deviceList = manager.deviceList.values.toList()
             selector(getString(R.string.headline_found_usb_devices), deviceList.map { "${it.manufacturerName} ${it.productName} (${String.format("%04x", it.vendorId)}:${String.format("%04x", it.productId)})" }) { dialogInterface, i ->
-                val permissionIntent = PendingIntent.getBroadcast(activity, 0, Intent(ACTION_USB_PERMISSION), 0)
+                val permissionIntent = PendingIntent.getBroadcast(activity, 0, Intent(ACTION_USB_PERMISSION),
+                        if (Build.VERSION.SDK_INT >= 23) { PendingIntent.FLAG_IMMUTABLE } else { 0 })
                 manager.requestPermission(deviceList[i], permissionIntent)
             }
         }


### PR DESCRIPTION
Todo:

- [x] Test that printing works after app was in background for a while and after reboot
  - [x] A12
  - [x] A13
- [x] Update Bluetooth permissions
- [x] Check if [Notification Permission](https://blog.esper.io/android-13-deep-dive/#notification_permission) is required
- [x] Test system printer on Android 13
- [x] Test network printing on Android 13
- [x] Test USB printing on Android 13
  - [x] Test reconnecting USB device and rebooting Android device keeps permission
- [x] Test bluetooth pairing on Android 13
- [x] Test bluetooth printing on Android 13
- [x] Test bluetooth pairing on Android 10, 11, 12
- [x] Test bluetooth printing on Android 10, 11, 12 (test print)
- [x] Test bluetooth printing on Android 10, 11, 12 (service print)
- [x] Test Evolis SDK on Android 13
- [ ] Test Zebra SDK on Android 13