### PR TITLE
Printer settings menu & delete

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/PrinterPreference.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/PrinterPreference.kt
@@ -1,0 +1,54 @@
+package eu.pretix.pretixprint.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.View.VISIBLE
+import android.widget.ImageButton
+import androidx.appcompat.widget.PopupMenu
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import eu.pretix.pretixprint.R
+
+class PrinterPreference(context: Context, attrs: AttributeSet, defStyleAttr: Int) :
+    Preference(context, attrs, defStyleAttr) {
+
+    constructor(context: Context, attrs: AttributeSet) : this(context, attrs, 0)
+
+    private val mLayoutResId: Int = R.layout.preference_two_target
+    private val mWidgetLayoutResId = R.layout.preference_more_button
+
+    private var button: ImageButton? = null
+    private var divider: View? = null
+
+    var setOnMenuItemClickListener = fun(_: MenuItem): Boolean { return false }
+    var moreVisibility = VISIBLE
+        set(value) {
+            field = value
+            divider?.visibility = moreVisibility
+            button?.visibility = moreVisibility
+        }
+
+
+    init {
+        layoutResource = mLayoutResId
+        widgetLayoutResource = mWidgetLayoutResId
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        divider = holder.itemView.findViewById(R.id.two_target_divider)
+        button = holder.itemView.findViewById(R.id.iBMore)
+        val popup = PopupMenu(context, button!!)
+        val inflater: MenuInflater = popup.menuInflater
+        inflater.inflate(R.menu.menu_printer_operations, popup.menu)
+        popup.setOnMenuItemClickListener(setOnMenuItemClickListener)
+        button?.setOnClickListener {
+            popup.show()
+        }
+        divider?.visibility = moreVisibility
+        button?.visibility = moreVisibility
+        super.onBindViewHolder(holder)
+    }
+}

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/Settings.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/Settings.kt
@@ -95,20 +95,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
     override fun onResume() {
         super.onResume()
         for (type in types) {
-            val connection = defaultSharedPreferences.getString("hardware_${type}printer_connection", "network_printer")
-
-            if (!TextUtils.isEmpty(defaultSharedPreferences.getString("hardware_${type}printer_ip", ""))) {
-                val ip = defaultSharedPreferences.getString("hardware_${type}printer_ip", "")
-                val name = defaultSharedPreferences.getString("hardware_${type}printer_printername", "")
-
-                findPreference<Preference>("hardware_${type}printer_find")?.summary = getString(
-                        R.string.pref_printer_current, name, ip, getString(resources.getIdentifier(connection, "string", requireActivity().packageName))
-                )
-            } else if (!TextUtils.isEmpty(defaultSharedPreferences.getString("hardware_${type}printer_connection", ""))) {
-                findPreference<Preference>("hardware_${type}printer_find")?.summary = getString(R.string.pref_printer_current_short,
-                    getString(resources.getIdentifier(connection, "string", requireActivity().packageName)))
-            } else {
-                findPreference<Preference>("hardware_${type}printer_find")?.summary = ""
+            val pref = findPreference<Preference>("hardware_${type}printer_find")
+            if (pref != null) {
+                if (!TextUtils.isEmpty(defaultSharedPreferences.getString("hardware_${type}printer_ip", ""))) {
+                    pref.summary = printerSummary(type)
+               } else {
+                    pref.summary = ""
+                }
             }
         }
 
@@ -120,6 +113,13 @@ class SettingsFragment : PreferenceFragmentCompat() {
                 getString(R.string.pref_printer_cpl, (cpl.entries.indexOf(cpl.entry) + 1).toString())
             }
         }
+    }
+
+    private fun printerSummary(type: String): String {
+        val ip = defaultSharedPreferences.getString("hardware_${type}printer_ip", "")
+        val name = defaultSharedPreferences.getString("hardware_${type}printer_printername", "")
+        val connection = defaultSharedPreferences.getString("hardware_${type}printer_connection", "network_printer")
+        return getString(R.string.pref_printer_current, name, ip, getString(resources.getIdentifier(connection, "string", requireActivity().packageName)))
     }
 
     private fun asset_dialog(@StringRes title: Int) {

--- a/pretixprint/app/src/main/res/drawable/ic_baseline_more_vert_24dp.xml
+++ b/pretixprint/app/src/main/res/drawable/ic_baseline_more_vert_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12,8c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM12,10c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2zM12,16c-1.1,0 -2,0.9 -2,2s0.9,2 2,2 2,-0.9 2,-2 -0.9,-2 -2,-2z"/>
+</vector>

--- a/pretixprint/app/src/main/res/layout/preference_more_button.xml
+++ b/pretixprint/app/src/main/res/layout/preference_more_button.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <ImageButton
+        android:id="@+id/iBMore"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_baseline_more_vert_24dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/pretixprint/app/src/main/res/layout/preference_two_target.xml
+++ b/pretixprint/app/src/main/res/layout/preference_two_target.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2017 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+<!-- Based off preference_two_target.xml from packages/SettingsLib -->
+<!-- Based off preference_material_settings.xml except that ripple on only on the left side. -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:gravity="center_vertical"
+    android:background="@android:color/transparent"
+    android:clipToPadding="false">
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:background="?android:attr/selectableItemBackground"
+        android:gravity="start|center_vertical"
+        android:clipToPadding="false"
+        android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+        android:paddingEnd="?android:attr/listPreferredItemPaddingEnd">
+        <LinearLayout
+            android:id="@+id/icon_frame"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="start|center_vertical"
+            android:minWidth="56dp"
+            android:orientation="horizontal"
+            android:clipToPadding="false"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp">
+            <!--
+            <androidx.preference.internal.PreferenceImageView
+                android:id="@android:id/icon"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                settings:maxWidth="48dp"
+                settings:maxHeight="48dp" />
+            -->
+        </LinearLayout>
+        <RelativeLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp">
+            <TextView
+                android:id="@android:id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:singleLine="true"
+                android:textAppearance="?android:attr/textAppearanceListItem"
+                android:ellipsize="marquee" />
+            <TextView
+                android:id="@android:id/summary"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_below="@android:id/title"
+                android:layout_alignStart="@android:id/title"
+                android:textAppearance="?attr/textAppearanceListItemSecondary"
+                android:textColor="?android:attr/textColorSecondary"
+                android:maxLines="10" />
+        </RelativeLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/two_target_divider"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:gravity="start|center_vertical"
+        android:orientation="horizontal"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp">
+        <View
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:background="?android:attr/listDivider" />
+    </LinearLayout>
+
+    <!-- Preference should place its actual preference widget here. -->
+    <LinearLayout
+        android:id="@android:id/widget_frame"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:minWidth="64dp"
+        android:gravity="center"
+        android:orientation="vertical" />
+</LinearLayout>

--- a/pretixprint/app/src/main/res/menu/menu_printer_operations.xml
+++ b/pretixprint/app/src/main/res/menu/menu_printer_operations.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <!--<item
+        android:id="@+id/maintenance"
+        android:title="Maintenance Mode" />-->
+    <item
+        android:id="@+id/remove"
+        android:title="@string/action_delete" />
+</menu>

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -48,8 +48,10 @@
     <string name="err_field_required">Dieses Feld ist erforderlich.</string>
     <string name="action_cancel">Abbrechen</string>
     <string name="action_save">Speichern</string>
+    <string name="action_delete">Entfernen</string>
     <string name="pref_printer_current">Aktuell in Verwendung: %s @ %s (%s)</string>
     <string name="pref_printer_current_short">Aktuell in Verwendung: %s</string>
+    <string name="pref_delete_printer">%s entfernen?</string>
     <string name="button_label_test">Testseite drucken</string>
     <string name="dismiss">Schließen</string>
     <string name="field_label_macaddress">MAC Addresse</string>

--- a/pretixprint/app/src/main/res/values/strings.xml
+++ b/pretixprint/app/src/main/res/values/strings.xml
@@ -57,8 +57,10 @@
     <string name="err_field_invalid">This field is invalid.</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_save">Save</string>
+    <string name="action_delete">Delete</string>
     <string name="pref_printer_current">Currently using printer %s @ %s (%s)</string>
     <string name="pref_printer_current_short">Currently using printer %s</string>
+    <string name="pref_delete_printer">Delete %s?</string>
     <string name="button_label_test">Print test page</string>
     <string name="bluetooth_printer">Bluetooth Printer</string>
     <string name="network_printer">Network Printer</string>

--- a/pretixprint/app/src/main/res/values/styles.xml
+++ b/pretixprint/app/src/main/res/values/styles.xml
@@ -8,6 +8,8 @@
         <item name="android:windowActionBarOverlay">true</item>
         <item name="actionBarTheme">@style/ThemeOverlay.App.ActionBar</item>
         <item name="preferenceTheme">@style/ThemeOverlay.App.Preference</item>
+        <!-- natively available on api level 21+ -->
+        <item name="textAppearanceListItemSecondary">@style/TextAppearance.AppCompat.Body1</item>
     </style>
 
     <style name="ThemeOverlay.App.Preference" parent="PreferenceThemeOverlay">

--- a/pretixprint/app/src/main/res/xml/preferences.xml
+++ b/pretixprint/app/src/main/res/xml/preferences.xml
@@ -3,21 +3,24 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/settings_label_ticketprinter">
-        <Preference
+        <eu.pretix.pretixprint.ui.PrinterPreference
             android:key="hardware_ticketprinter_find"
             android:title="@string/settings_label_find"
             />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_label_badgeprinter">
-        <Preference
+        <eu.pretix.pretixprint.ui.PrinterPreference
             android:key="hardware_badgeprinter_find"
             android:title="@string/settings_label_find"
             />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_label_receiptprinter">
-        <Preference android:key="hardware_receiptprinter_find" android:title="@string/settings_label_find"/>
+        <eu.pretix.pretixprint.ui.PrinterPreference
+            android:key="hardware_receiptprinter_find"
+            android:title="@string/settings_label_find"
+            />
         <eu.pretix.pretixprint.ui.ProtectedListPreference
             android:entries="@array/receipt_width"
             android:entryValues="@array/receipt_cpl"

--- a/pretixprint/app/src/main/res/xml/preferences.xml
+++ b/pretixprint/app/src/main/res/xml/preferences.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/settings_label_ticketprinter">
         <Preference


### PR DESCRIPTION
Extracted from #28: Printer Settings now have a kebab menu to the right that enables users to delete a configured printer again.

![image](https://github.com/pretix/pretixprint-android/assets/172415/2fca0539-9194-4b3e-afe8-887173bf577a)
