### PR TITLE
Label mode printing for Sunmi devices with integrated printer

### DIFF
--- a/pretixprint/app/build.gradle
+++ b/pretixprint/app/build.gradle
@@ -133,6 +133,7 @@ dependencies {
 
     implementation 'com.github.anastaciocintra:escpos-coffee:4.0.2'
     implementation 'com.sunmi:printerlibrary:1.0.13'
+    implementation 'com.sunmi:printerx:1.0.12'  // Documentation: https://developer.sunmi.com/docs/en-US/xeghjk491/maceghjk502
 
     // Evolis SDK
     fullImplementation(project(':EvolisSDK')) {

--- a/pretixprint/app/src/foss/java/eu/pretix/pretixprint/byteprotocols/Registry.kt
+++ b/pretixprint/app/src/foss/java/eu/pretix/pretixprint/byteprotocols/Registry.kt
@@ -9,5 +9,6 @@ val protocols = listOf<ByteProtocolInterface<*>>(
         GraphicESCPOS(),
         GraphicePOSPrintXML(),
         BrotherRaster(),
-        PNG()
+        PNG(),
+        SunmiPrinterXLabels(),
 )

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/Registry.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/Registry.kt
@@ -11,6 +11,7 @@ val protocols = listOf<ByteProtocolInterface<*>>(
         BrotherRaster(),
         EvolisDirect(),
         PNG(),
+        SunmiPrinterXLabels(),
         LinkOSCard(),
         LinkOS()
 )

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/Interface.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/Interface.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import com.sunmi.peripheral.printer.SunmiPrinterService
+import com.sunmi.printerx.PrinterSdk
 import eu.pretix.pretixprint.connections.ConnectionType
 import eu.pretix.pretixprint.ui.SetupFragment
 import java8.util.concurrent.CompletableFuture
@@ -36,6 +37,10 @@ interface CustomByteProtocol<T> : ByteProtocolInterface<T> {
 
 interface SunmiByteProtocol<T> : ByteProtocolInterface<T> {
     fun sendSunmi(printerService: SunmiPrinterService, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String)
+}
+
+interface SunmiPrinterXByteProtocol<T> : ByteProtocolInterface<T> {
+    fun sendSunmi(printer: PrinterSdk.Printer, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String)
 }
 
 fun getProtoClass(proto: String): ByteProtocolInterface<Any> {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/SunmiPrinterXLabels.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/SunmiPrinterXLabels.kt
@@ -1,0 +1,99 @@
+package eu.pretix.pretixprint.byteprotocols
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.util.Log
+import com.sunmi.printerx.PrinterSdk
+import com.sunmi.printerx.api.PrintResult
+import com.sunmi.printerx.enums.ImageAlgorithm
+import com.sunmi.printerx.style.BaseStyle
+import com.sunmi.printerx.style.BitmapStyle
+import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.connections.ConnectionType
+import eu.pretix.pretixprint.connections.SunmiInternalConnection
+import eu.pretix.pretixprint.ui.SetupFragment
+import eu.pretix.pretixprint.ui.SunmiPrinterXLabelsSettingsFragment
+import java8.util.concurrent.CompletableFuture
+import java.io.ByteArrayOutputStream
+import java.util.concurrent.TimeUnit
+
+// Documentation: https://developer.sunmi.com/docs/en-US/xeghjk491/mameghjk546
+class SunmiPrinterXLabels : SunmiPrinterXByteProtocol<Bitmap> {
+    override val identifier = "SunmiPrinterXLabels"
+    override val nameResource = R.string.protocol_sunmi_printerx_labels
+    override val defaultDPI = 300  // Printer is natively 203dpi, but prints look better when rendered at 300dpi
+    override val demopage = "demopage_8in_3.25in.pdf"
+
+    override fun allowedForUsecase(type: String): Boolean {
+        return type == "badge"
+    }
+
+    override fun allowedForConnection(type: ConnectionType): Boolean {
+        return type is SunmiInternalConnection
+    }
+
+    override fun convertPageToBytes(img: Bitmap, isLastPage: Boolean, previousPage: Bitmap?, conf: Map<String, String>, type: String): ByteArray {
+        val stream = ByteArrayOutputStream()
+        img.compress(Bitmap.CompressFormat.PNG, 100, stream)
+        val byteArray = stream.toByteArray()
+        img.recycle()
+        return byteArray
+    }
+
+    override fun sendSunmi(printer: PrinterSdk.Printer, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String) {
+        for (f in pages) {
+            Log.i("PrintService", "Waiting for page to be converted")
+            val page = f.get(60, TimeUnit.SECONDS)
+            Log.i("PrintService", "Page ready, sending page")
+            val bmp = BitmapFactory.decodeByteArray(page, 0, page.size)
+
+            // Get configuration parameters
+            val printWidth = (conf.get("hardware_${type}printer_sunmiprinterxlabels_print_width")!!).toInt()
+            val rollWidth = (conf.get("hardware_${type}printer_sunmiprinterxlabels_roll_width")!!).toInt()
+            val labelWidth = (conf.get("hardware_${type}printer_sunmiprinterxlabels_label_width")!!).toInt()
+            val labelHeight = (conf.get("hardware_${type}printer_sunmiprinterxlabels_label_height")!!).toInt()
+
+            // Calculate canvas
+            val totalPrinterMargin = if (printWidth == 58) 10 else 8
+            val totalLinerMargin = rollWidth - labelWidth
+
+            val totalHorizontalMargin = maxOf(totalPrinterMargin, totalLinerMargin)
+
+
+            val imageWidth = (rollWidth -  totalHorizontalMargin) * 8 // 8px per mm
+            val imageHeight = labelHeight * 8
+
+            val x0 = (totalHorizontalMargin - totalPrinterMargin) * (8/2)
+            val y0 = 0
+
+            val canvasWidth = x0 + imageWidth
+            val canvasHeight = imageHeight
+
+            // Print
+            printer.canvasApi().run {
+                initCanvas(BaseStyle.getStyle().setWidth(canvasWidth).setHeight(canvasHeight))
+                renderBitmap(bmp, BitmapStyle.getStyle().setPosX(x0).setPosX(y0).setWidth(imageWidth).setHeight(imageHeight).setAlgorithm(ImageAlgorithm.BINARIZATION))
+                printCanvas(1, object : PrintResult() {
+                    override fun onResult(resultCode: Int, message: String?) {
+                        if (resultCode == 0) {
+                            // Print successful
+                        } else {
+                            println(printer.queryApi()?.status)
+                        }
+                    }
+
+                })
+            }
+
+
+        }
+    }
+
+    override fun createSettingsFragment(): SetupFragment {
+        return SunmiPrinterXLabelsSettingsFragment()
+    }
+
+    override fun inputClass(): Class<Bitmap> {
+        return Bitmap::class.java
+    }
+}

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Bluetooth.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Bluetooth.kt
@@ -11,6 +11,7 @@ import eu.pretix.pretixprint.R
 import eu.pretix.pretixprint.byteprotocols.CustomByteProtocol
 import eu.pretix.pretixprint.byteprotocols.StreamByteProtocol
 import eu.pretix.pretixprint.byteprotocols.SunmiByteProtocol
+import eu.pretix.pretixprint.byteprotocols.SunmiPrinterXByteProtocol
 import eu.pretix.pretixprint.byteprotocols.getProtoClass
 import eu.pretix.pretixprint.print.lockManager
 import eu.pretix.pretixprint.renderers.renderPages
@@ -117,6 +118,10 @@ class BluetoothConnection : ConnectionType {
                         Log.i("PrintService", "Finished proto.sendBluetooth()")
                     }
                     is SunmiByteProtocol -> {
+                        throw PrintException("Unsupported combination")
+                    }
+
+                    is SunmiPrinterXByteProtocol -> {
                         throw PrintException("Unsupported combination")
                     }
                 }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Network.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Network.kt
@@ -82,6 +82,9 @@ class NetworkConnection : ConnectionType {
                     is SunmiByteProtocol -> {
                         throw PrintException("Unsupported combination")
                     }
+                    is SunmiPrinterXByteProtocol -> {
+                        throw PrintException("Unsupported combination")
+                    }
                 }
             }
         } catch (e: TimeoutException) {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
@@ -398,6 +398,10 @@ open class USBConnection : ConnectionType {
                                         is SunmiByteProtocol -> {
                                             throw PrintException("Unsupported combination")
                                         }
+
+                                        is SunmiPrinterXByteProtocol -> {
+                                            throw PrintException("Unsupported combination")
+                                        }
                                     }
                                 }
                             } catch (e: TimeoutException) {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/SunmiPrinterXLabelsSettingsFragment.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/SunmiPrinterXLabelsSettingsFragment.kt
@@ -1,0 +1,179 @@
+package eu.pretix.pretixprint.ui
+
+import android.os.Bundle
+import android.text.TextUtils
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.AutoCompleteTextView
+import android.widget.Button
+import androidx.preference.PreferenceManager
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+import eu.pretix.pretixprint.R
+import eu.pretix.pretixprint.Rotation
+
+class SunmiPrinterXLabelsSettingsFragment : SetupFragment() {
+
+    override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+    ): View {
+        val prefs = PreferenceManager.getDefaultSharedPreferences(requireContext())
+        val view = inflater.inflate(R.layout.fragment_sunmiprinterxlabels_settings, container, false)
+
+        val currentRollWidth = (activity as PrinterSetupActivity).settingsStagingArea.get(
+                "hardware_${useCase}printer_sunmiprinterxlabels_roll_width"
+        ) ?: prefs.getString("hardware_${useCase}printer_sunmiprinterxlabels_roll_width", "")
+        view.findViewById<TextInputEditText>(R.id.teRollWidth).setText(currentRollWidth)
+
+        val currentLabelWidth = (activity as PrinterSetupActivity).settingsStagingArea.get(
+            "hardware_${useCase}printer_sunmiprinterxlabels_label_width"
+        ) ?: prefs.getString("hardware_${useCase}printer_sunmiprinterxlabels_label_width", "")
+        view.findViewById<TextInputEditText>(R.id.teLabelWidth).setText(currentLabelWidth)
+
+        val currentLabelHeight = (activity as PrinterSetupActivity).settingsStagingArea.get(
+            "hardware_${useCase}printer_sunmiprinterxlabels_label_height"
+        ) ?: prefs.getString("hardware_${useCase}printer_sunmiprinterxlabels_label_height", "")
+        view.findViewById<TextInputEditText>(R.id.teLabelHeight).setText(currentLabelHeight)
+
+        val printWidthAdapter = ArrayAdapter(requireContext(), R.layout.list_item, PrintWidth.values().map {
+            it.toString()
+        })
+        (view.findViewById<TextInputLayout>(R.id.tilPrintWidth).editText as? AutoCompleteTextView)?.setAdapter(printWidthAdapter)
+        val chosenPrintWidth = ((activity as PrinterSetupActivity).settingsStagingArea.get(
+            "hardware_${useCase}printer_sunmiprinterxlabels_print_width"
+        )) ?: prefs.getString("hardware_${useCase}printer_sunmiprinterxlabels_print_width", "58")
+        if (chosenPrintWidth?.isNotEmpty() == true) {
+            val chosenLabel = PrintWidth.values().find { it.paperWidthMm == Integer.valueOf(chosenPrintWidth) }!!.toString()
+            (view.findViewById<TextInputLayout>(R.id.tilPrintWidth).editText as? AutoCompleteTextView)?.setText(chosenLabel, false)
+        }
+
+        val rotationAdapter = ArrayAdapter(requireContext(), R.layout.list_item, Rotation.values().map {
+            it.toString()
+        })
+        (view.findViewById<TextInputLayout>(R.id.tilRotation).editText as? AutoCompleteTextView)?.setAdapter(rotationAdapter)
+        val chosenRotation = ((activity as PrinterSetupActivity).settingsStagingArea.get(
+            "hardware_${useCase}printer_rotation"
+        )) ?: prefs.getString("hardware_${useCase}printer_rotation", "0")
+        if (chosenRotation?.isNotEmpty() == true) {
+            val chosenLabel = Rotation.values().find { it.degrees == Integer.valueOf(chosenRotation) }!!.toString()
+            (view.findViewById<TextInputLayout>(R.id.tilRotation).editText as? AutoCompleteTextView)?.setText(chosenLabel, false)
+        }
+
+        view.findViewById<Button>(R.id.btnPrev).setOnClickListener {
+            back()
+        }
+        view.findViewById<Button>(R.id.btnNext).setOnClickListener {
+            var noErrors = true
+
+            val teRollWidth = view.findViewById<TextInputEditText>(R.id.teRollWidth)
+            val teLabelWidth = view.findViewById<TextInputEditText>(R.id.teLabelWidth)
+            val teLabelHeight = view.findViewById<TextInputEditText>(R.id.teLabelHeight)
+
+            val printWidth = view.findViewById<TextInputLayout>(R.id.tilPrintWidth).editText?.text.toString()
+            val mappedPrintWidth = PrintWidth.values().find {it.toString() == printWidth}!!.paperWidthMm
+            val rollWidth = teRollWidth.text.toString()
+            val labelWidth = teLabelWidth.text.toString()
+            val labelHeight = teLabelHeight.text.toString()
+            val rotation = view.findViewById<TextInputLayout>(R.id.tilRotation).editText?.text.toString()
+            val mappedRotation = Rotation.values().find { it.toString() == rotation }!!.degrees
+
+            // Validation of entered data
+            if (TextUtils.isEmpty(rollWidth)) {
+                teRollWidth.error = getString(R.string.err_field_required)
+                noErrors = false
+            } else if (!TextUtils.isDigitsOnly(rollWidth)) {
+                teRollWidth.error = getString(R.string.err_field_invalid)
+            } else if (Integer.parseInt(rollWidth) < 30) {
+                teRollWidth.error = getString(R.string.err_field_sunmiprinterxlabels_roll_width_small)
+                noErrors = false
+            } else if (Integer.parseInt(rollWidth) > mappedPrintWidth) {
+                teRollWidth.error = getString(R.string.err_field_sunmiprinterxlabels_roll_width_large)
+                noErrors = false
+            } else {
+                teRollWidth.error = null
+            }
+
+            if (TextUtils.isEmpty(labelWidth)) {
+                teLabelWidth.error = getString(R.string.err_field_required)
+                noErrors = false
+            } else if (!TextUtils.isDigitsOnly(labelWidth)) {
+                teLabelWidth.error = getString(R.string.err_field_invalid)
+            } else if (Integer.parseInt(labelWidth) < 30-3) {
+                teLabelWidth.error = getString(R.string.err_field_sunmiprinterxlabels_label_width_small)
+                noErrors = false
+            } else if (Integer.parseInt(labelWidth) > Integer.parseInt(rollWidth)) {
+                teLabelWidth.error = getString(R.string.err_field_sunmiprinterxlabels_label_width_large)
+                noErrors = false
+            } else {
+                teLabelWidth.error = null
+            }
+
+            if (TextUtils.isEmpty(labelHeight)) {
+                teLabelHeight.error = getString(R.string.err_field_required)
+                noErrors = false
+            } else if (!TextUtils.isDigitsOnly(labelHeight)) {
+                teLabelHeight.error = getString(R.string.err_field_invalid)
+            } else if (Integer.parseInt(labelHeight) < 20) {
+                teLabelHeight.error = getString(R.string.err_field_sunmiprinterxlabels_label_height_small)
+                noErrors = false
+            } else {
+                teLabelHeight.error = null
+            }
+
+            if (noErrors) {
+
+                val totalPrinterMargin = if (mappedPrintWidth == 58) 10 else 8
+                val totalLinerMargin = Integer.parseInt(rollWidth) - Integer.parseInt(labelWidth)
+
+                val totalHorizontalMargin = maxOf(totalPrinterMargin, totalLinerMargin)
+
+                val designWidth : Int
+                val designHeight : Int
+
+                if ((mappedRotation == 90) or (mappedRotation == 270)) {
+                    designWidth = Integer.parseInt(labelHeight)
+                    designHeight = Integer.parseInt(rollWidth) - totalHorizontalMargin
+
+                } else {
+                    designWidth = Integer.parseInt(rollWidth) -  totalHorizontalMargin
+                    designHeight = Integer.parseInt(labelHeight)
+                }
+
+                MaterialAlertDialogBuilder(requireContext())
+                    .setTitle(getString(R.string.title_design_dimensions))
+                    .setMessage(getString(R.string.dialog_calculated_dimensions, designWidth, designHeight))
+                    .setPositiveButton(getString(R.string.btn_ok)) { dialog, which -> }
+                    .show()
+
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_sunmiprinterxlabels_print_width", mappedPrintWidth.toString())
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_sunmiprinterxlabels_roll_width", rollWidth)
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_sunmiprinterxlabels_label_width", labelWidth)
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_sunmiprinterxlabels_label_height", labelHeight)
+                (activity as PrinterSetupActivity).settingsStagingArea.put("hardware_${useCase}printer_rotation", mappedRotation.toString())
+                (activity as PrinterSetupActivity).startFinalPage()
+            }
+
+
+        }
+
+        return view
+    }
+
+    override fun back() {
+        (activity as PrinterSetupActivity).startProtocolChoice(true)
+    }
+}
+
+enum class PrintWidth(val paperWidthMm: Int, val printableWidthMm: Int, val printableWidthPx: Int) {
+    mm58(paperWidthMm = 58, printableWidthMm = 48, printableWidthPx = 384),
+    mm80(paperWidthMm = 80, printableWidthMm = 72, printableWidthPx = 576);
+
+    override fun toString(): String {
+        return "$paperWidthMm mm"
+    }
+}

--- a/pretixprint/app/src/main/res/layout/fragment_sunmiprinterxlabels_settings.xml
+++ b/pretixprint/app/src/main/res/layout/fragment_sunmiprinterxlabels_settings.xml
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:id="@+id/scroll"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:fadeScrollbars="false"
+        app:layout_constraintBottom_toTopOf="@id/bottomNavBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/textView5"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/setup_protocol_settings"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilPrintWidth"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:helperText="@string/field_helper_sunmiprinterxlabels_print_width"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/textView5"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
+
+            <AutoCompleteTextView
+                android:id="@+id/tePrintWidth"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/field_label_sunmipprinterxlabels_print_width"
+                android:inputType="none" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilRollWidth"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tilPrintWidth">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/teRollWidth"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/field_label_sunmiprinterxlabels_roll_width"
+                    android:inputType="number" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilLabelWidth"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:helperText="@string/field_helper_sunmiprinterxlabels_label_width"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tilRollWidth">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/teLabelWidth"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/field_label_sunmiprinterxlabels_label_width"
+                    android:inputType="number" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilLabelHeight"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:helperText="@string/field_helper_sunmiprinterxlabels_label_height"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/tilLabelWidth">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/teLabelHeight"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/field_label_sunmiprinterxlabels_label_height"
+                    android:inputType="number" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilRotation"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/tilLabelHeight"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
+
+                <AutoCompleteTextView
+                    android:id="@+id/teRotation"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/field_label_rotation"
+                    android:inputType="none" />
+            </com.google.android.material.textfield.TextInputLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+
+    <include
+        layout="@layout/include_settings_buttons"
+        android:id="@+id/bottomNavBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintVertical_bias="1.0"
+        app:layout_constraintBottom_toBottomOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -139,4 +139,20 @@
     <string name="pin_protection_pin">Einstellungen-PIN setzen</string>
     <string name="pin_protection_description">Einstellungen mit einer selbstgewählten PIN sperren, die zum Ändern der Drucker-Konfiguration eingegeben werden muss</string>
     <string name="operation_pin_headline">PIN eingeben</string>
+    <string name="protocol_sunmi_printerx_labels">Sunmi Etikettendrucker</string>
+    <string name="field_helper_sunmiprinterxlabels_print_width">Stellen Sie sicher, dass in den Systemeinstellungen auch in den Druckeinstellungen des Geräts die gleiche Druckbreite eingestellt ist. Bitte stellen Sie außerdem sicher, dass das Gerät auf den \"Label Modus\" eingestellt ist. Wenn bei "Label prüfen" der Studienmodus auf \"Manuell\" eingestellt ist, muss eine manuelle Studie durchgeführt werden, um die Lücken für Ihre Etikettenrolle korrekt zu identifizieren.</string>
+    <string name="field_label_sunmipprinterxlabels_print_width">Druckbreite</string>
+    <string name="field_label_sunmiprinterxlabels_roll_width">Rollenbreite (mm)</string>
+    <string name="field_label_sunmiprinterxlabels_label_width">Etikettenbreite (mm)</string>
+    <string name="field_label_sunmiprinterxlabels_label_height">Etikettenhöhe (mm)</string>
+    <string name="field_helper_sunmiprinterxlabels_label_width">Breite entlang der gleichen Richtung wie die Rollenbreite</string>
+    <string name="field_helper_sunmiprinterxlabels_label_height">Höhe entlang der Abrollrichtung der Rolle</string>
+    <string name="err_field_sunmiprinterxlabels_roll_width_small">Die Rolle sollte mindestens 30 mm breit sein</string>
+    <string name="err_field_sunmiprinterxlabels_roll_width_large">Die Rollenbreite darf nicht größer sein als die Druckbreite</string>
+    <string name="err_field_sunmiprinterxlabels_label_width_large">Die Etikettenbreite darf nicht größer als die Rollenbreite sein</string>
+    <string name="err_field_sunmiprinterxlabels_label_width_small">Die Etikettenbreite sollte mindestens 27 mm betragen</string>
+    <string name="err_field_sunmiprinterxlabels_label_height_small">Die Etikettenhöhe sollte mindestens 20 mm betragen</string>
+    <string name="title_design_dimensions">Designmaße</string>
+    <string name="btn_ok">Okay</string>
+    <string name="dialog_calculated_dimensions">Bitte verwenden Sie im Pretix PDF-Editor folgende Maße:\nBreite: %1$d mm\nHöhe: %2$d mm</string>
 </resources>

--- a/pretixprint/app/src/main/res/values/strings.xml
+++ b/pretixprint/app/src/main/res/values/strings.xml
@@ -139,4 +139,20 @@
     <string name="pin_protection_pin">Set settings PIN</string>
     <string name="pin_protection_description">Lock settings with a custom PIN that must be entered if you want to change printer configuration</string>
     <string name="operation_pin_headline">Enter PIN</string>
+    <string name="protocol_sunmi_printerx_labels">Sunmi label printer</string>
+    <string name="field_helper_sunmiprinterxlabels_print_width">Make sure that the same print width is also set in the device\'s printer settings in the system settings. Please also ensure that the device is set to \"label mode\". If the study mode is set to manual, a manual study must be done to correctly identify the gaps for your label roll.</string>
+    <string name="field_label_sunmipprinterxlabels_print_width">Print width</string>
+    <string name="field_label_sunmiprinterxlabels_roll_width">Roll width (mm)</string>
+    <string name="field_label_sunmiprinterxlabels_label_width">Label width (mm)</string>
+    <string name="field_label_sunmiprinterxlabels_label_height">Label height (mm)</string>
+    <string name="field_helper_sunmiprinterxlabels_label_width">Width along the same direction as the roll width</string>
+    <string name="field_helper_sunmiprinterxlabels_label_height">Height along the direction of the unrolling roll</string>
+    <string name="err_field_sunmiprinterxlabels_roll_width_small">The roll should be at least 30mm wide</string>
+    <string name="err_field_sunmiprinterxlabels_roll_width_large">The roll width cannot be larger than the print width</string>
+    <string name="err_field_sunmiprinterxlabels_label_width_large">The label width cannot be larger than the roll width</string>
+    <string name="err_field_sunmiprinterxlabels_label_width_small">The label width should be at least 27mm</string>
+    <string name="err_field_sunmiprinterxlabels_label_height_small">The label height should be at least 20mm</string>
+    <string name="title_design_dimensions">Design dimensions</string>
+    <string name="btn_ok">Okay</string>
+    <string name="dialog_calculated_dimensions">Please use the following dimensions in the pretix PDF-editor:\nWidth: %1$d mm\nHeight: %2$d mm</string>
 </resources>


### PR DESCRIPTION
This implementation extends and improves the support for printing on Sunmi devices, more specifically for badge printing.

It implements support for "label mode" (and should also work for "black mark mode") printing on compatible Sunmi devices for printing badges, where the device makes sure that the print is well aligned/synchronised to the start of a label. After printing the label, it also feeds the roll to the correct position in a gap between 2 labels to tear off the printed label(s). The device will retreat the fed paper again a bit, when necessary, at the start of the next print job so that also subsequent prints are aligned correctly with respect to their labels.

It supports devices with both a 58mm printer and an 80mm printer. It is flexible towards all device-compatible label sizes.

This implementation was tested on a Sunmi V2s Plus device (P06050006). The combination of a built-in 2D scanner engine and an 80mm printer makes it a very interesting mobile all-in-one device for validating pretix tickets as well as badge printing.

Sources:
* [SUNMI Printing SDK Overview](https://developer.sunmi.com/docs/en-US/xeghjk491/maceghjk502)
* [APIs for Printing Labels & Receipts](https://developer.sunmi.com/docs/en-US/xeghjk491/mameghjk546)