### PR TITLE
Use CodeTable that works for older and newer printer generations of the iMin Falcon (Z#23131770)

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/ESCPOSRenderer.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/ESCPOSRenderer.kt
@@ -56,7 +56,6 @@ class ESCPOSRenderer(private val dialect: Dialect, private val receipt: JSONObje
             Thai17(25),
             Thai18(26),
             StarCp1252(32),
-            IminCp1250(0x48),
             UserDefined1(254),
             UserDefined2(255)
         }
@@ -125,7 +124,7 @@ class ESCPOSRenderer(private val dialect: Dialect, private val receipt: JSONObje
             }
             Dialect.IMin -> {
                 cancelKanjiCharacterMode()
-                characterCodeTable(CharacterCodeTable.IminCp1250.codeTable)
+                characterCodeTable(CharacterCodeTable.WPC1252.codeTable)
             }
         }
 
@@ -863,7 +862,7 @@ class ESCPOSRenderer(private val dialect: Dialect, private val receipt: JSONObje
             }
             Dialect.IMin -> {
                 cancelKanjiCharacterMode()
-                characterCodeTable(CharacterCodeTable.IminCp1250.codeTable)
+                characterCodeTable(CharacterCodeTable.WPC1252.codeTable)
             }
         }
         qr("TEST COMPLETED", 6)


### PR DESCRIPTION
The newer iMin printer generation didn't understand the IminCp1250 code table (0x48) and broke printing of german umlauts.

Old: hardware ms-sge-v3, firmware app22-08-24 d1
New: hardware ms-sge-w27, firmware app23-09-06 d1