### PR TITLE
Add lock around UsbManager.requestPermission

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
@@ -378,6 +378,7 @@ open class USBConnection : ConnectionType {
                         val device: UsbDevice = intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)!!
                         if (device.deviceId != requestedDevice.deviceId) {
                             Log.i("PrintService", "[$type] Ignored wrong USB device ${device.serialNumber}")
+                            return
                         }
 
                         if (intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)) {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/Lock.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/Lock.kt
@@ -17,3 +17,4 @@ class LockManager() {
 
 
 val lockManager = LockManager()
+val usbPermissionLock = ReentrantLock()


### PR DESCRIPTION
If two print threads run at the same time and call

```
        context.registerReceiver(recv, filter)
        manager.requestPermission(requestedDevice, permissionIntent)
```

with specific concurrency, a race condition will cause the print job to go to the same printer. I was able to reproduce this by adding a few strategic sleep() calls in the code base. I was experimenting with intent filters, but the safest solution seems to be to guard this part of the process with a lock. 