### PR TITLE
Double Sided Printing

### DIFF
--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/EvolisDirect.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/EvolisDirect.kt
@@ -76,6 +76,7 @@ class EvolisDirect : CustomByteProtocol<Bitmap> {
         usbManager: UsbManager,
         usbDevice: UsbDevice,
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         conf: Map<String, String>,
         type: String,
         context: Context
@@ -85,24 +86,26 @@ class EvolisDirect : CustomByteProtocol<Bitmap> {
         }
         val parts = usbDevice.productName!!.trim().split(" ", limit = 2)
         val printer = EvolisPrinter(context, parts[0], parts[1])
-        send(pages, printer, conf, type, context)
+        send(pages, pagegroups, printer, conf, type, context)
     }
 
     override fun sendNetwork(
         host: String,
         port: Int,
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         conf: Map<String, String>,
         type: String,
         context: Context
     ) {
         val printer = EvolisPrinter(context, host)
-        send(pages, printer, conf, type, context)
+        send(pages, pagegroups, printer, conf, type, context)
     }
 
     override fun sendBluetooth(
         deviceAddress: String,
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         conf: Map<String, String>,
         type: String,
         context: Context
@@ -112,6 +115,7 @@ class EvolisDirect : CustomByteProtocol<Bitmap> {
 
     private fun send(
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         printer: EvolisPrinter,
         conf: Map<String, String>,
         type: String,

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOS.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOS.kt
@@ -54,37 +54,37 @@ class LinkOS : CustomByteProtocol<Bitmap> {
         return ostream.toByteArray()
     }
 
-    override fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         val connection = UsbConnection(usbManager, usbDevice)
         try {
             connection.open()
-            send(pages, connection, conf, type, context)
+            send(pages, pagegroups, connection, conf, type, context)
         } finally {
             connection.close()
         }
     }
 
-    override fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         val connection = TcpConnection(host, port)
         try {
             connection.open()
-            send(pages, connection, conf, type, context)
+            send(pages, pagegroups, connection, conf, type, context)
         } finally {
             connection.close()
         }
     }
 
-    override fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         val connection = BluetoothConnectionInsecure(deviceAddress)
         try {
             connection.open()
-            send(pages, connection, conf, type, context)
+            send(pages, pagegroups, connection, conf, type, context)
         } finally {
             connection.close()
         }
     }
 
-    private fun send(pages: List<CompletableFuture<ByteArray>>, connection: Connection, conf: Map<String, String>, type: String, context: Context) {
+    private fun send(pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, connection: Connection, conf: Map<String, String>, type: String, context: Context) {
         fun getSetting(key: String, def: String): String {
             return conf[key] ?: PreferenceManager.getDefaultSharedPreferences(context).getString(key, def)!!
         }

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
@@ -54,37 +54,37 @@ class LinkOSCard : CustomByteProtocol<Bitmap> {
         return ostream.toByteArray()
     }
 
-    override fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         val connection = UsbConnection(usbManager, usbDevice)
         try {
             connection.open()
-            send(pages, connection, conf, type, context)
+            send(pages, pagegroups, connection, conf, type, context)
         } finally {
             connection.close()
         }
     }
 
-    override fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         val connection = TcpConnection(host, port)
         try {
             connection.open()
-            send(pages, connection, conf, type, context)
+            send(pages, pagegroups, connection, conf, type, context)
         } finally {
             connection.close()
         }
     }
 
-    override fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         val connection = BluetoothConnectionInsecure(deviceAddress)
         try {
             connection.open()
-            send(pages, connection, conf, type, context)
+            send(pages, pagegroups, connection, conf, type, context)
         } finally {
             connection.close()
         }
     }
 
-    private fun send(pages: List<CompletableFuture<ByteArray>>, connection: Connection, conf: Map<String, String>, type: String, context: Context) {
+    private fun send(pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, connection: Connection, conf: Map<String, String>, type: String, context: Context) {
         fun getSetting(key: String, def: String): String {
             return conf[key] ?: PreferenceManager.getDefaultSharedPreferences(context).getString(key, def)!!
         }
@@ -95,22 +95,64 @@ class LinkOSCard : CustomByteProtocol<Bitmap> {
             var zebraCardPrinter: ZebraCardPrinter? = null
 
             try {
-                var doubleSided = getSetting("hardware_${type}printer_doublesided", "false").toBoolean()
+                var forceDoubleSided = getSetting("hardware_${type}printer_doublesided", "false").toBoolean()
+                var canDoubleSided = false
                 val cardSource = getSetting("hardware_${type}printer_cardsource", "AutoDetect")
                 val cardDestination = getSetting("hardware_${type}printer_carddestination", "Eject")
 
                 zebraCardPrinter = ZebraCardPrinterFactory.getInstance(connection)
 
-                doubleSided = (zebraCardPrinter.printCapability == TransferType.DualSided && doubleSided)
+                canDoubleSided = zebraCardPrinter.printCapability == TransferType.DualSided
+                forceDoubleSided = (canDoubleSided && forceDoubleSided)
 
-                for (f in pages) {
+
+                var printJobs = mutableListOf<List<GraphicsInfo>>()
+                var pageoffset = 0
+                for (pagegroup in pagegroups) {
+                    if (forceDoubleSided) {
+                        // User requested to print everything double sided, so we will - no matter what.
+                        // A 2-page document will in this case yield 2 cards:
+                        // - card 1: page 1 + page 1
+                        // - card 2: page 2 + page 2
+                        for (i in 0 until pagegroup) {
+                            printJobs.add(drawGraphics(zebraCardPrinter, pages[pageoffset + i].get(60, TimeUnit.SECONDS), listOf(CardSide.Front, CardSide.Back), context))
+                        }
+                    } else if (canDoubleSided && pagegroup > 1) {
+                        // User did not requested everything to be printer double sided, but the printer
+                        // is still capable printing on both sides and the current group of pages is actually
+                        // more than one page. In this case, we print page 1 and 2 on one card.
+                        // Even remainders of the pagegroup will be processed as double sided prints,
+                        // any remainder will be printed on a single-sided card.
+                        for (i in 0 until pagegroup) {
+                            if (i % 2 == 0 && i == pagegroup-1) {
+                                // Even page (0, 2, 4, ...) and at last page of the group
+                                // --> Last page to print onto a single sided card
+                                printJobs.add(drawGraphics(zebraCardPrinter, pages[pageoffset + i].get(60, TimeUnit.SECONDS), listOf(CardSide.Front), context))
+                            } else if (i % 2 == 0) {
+                                // Even page (0, 2, 4, ...) but not last page of the group
+                                // --> CardSide.Front of a double sided card.
+                                printJobs.add(drawGraphics(zebraCardPrinter, pages[pageoffset + i].get(60, TimeUnit.SECONDS), listOf(CardSide.Front), context))
+                            } else {
+                                // Uneven page (1, 3, 5, ...)
+                                // --> CardSide.Back of a double sided card.
+                                printJobs[printJobs.lastIndex] = printJobs[printJobs.lastIndex] + drawGraphics(zebraCardPrinter, pages[pageoffset + i].get(60, TimeUnit.SECONDS), listOf(CardSide.Back), context)
+                            }
+                        }
+                    } else {
+                        // One page goes on one side of one card.
+                        for (i in 0 until pagegroup) {
+                            printJobs.add(drawGraphics(zebraCardPrinter, pages[pageoffset + i].get(60, TimeUnit.SECONDS), listOf(CardSide.Front), context))
+                        }
+                    }
+                    pageoffset += pagegroup
+                }
+
+                for (job in printJobs) {
                     zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.CARD_SOURCE, cardSource)
                     zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.CARD_DESTINATION, cardDestination)
                     zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.DELETE_AFTER, "yes")
 
-                    val graphicsData = drawGraphics(zebraCardPrinter, f.get(60, TimeUnit.SECONDS), doubleSided, context)
-
-                    val jobId = zebraCardPrinter.print(1, graphicsData)
+                    val jobId = zebraCardPrinter.print(1, job)
 
                     // Zebra Card printers only have a limited Job Buffer - in the case of the ZC-Series, it's
                     // 4 print jobs.
@@ -152,7 +194,7 @@ class LinkOSCard : CustomByteProtocol<Bitmap> {
         }
     }
 
-    private fun drawGraphics(zebraCardPrinter: ZebraCardPrinter, imageData: ByteArray, doubleSided: Boolean, context: Context) : List<GraphicsInfo> {
+    private fun drawGraphics(zebraCardPrinter: ZebraCardPrinter, imageData: ByteArray, cardSides: List<CardSide>, context: Context) : List<GraphicsInfo> {
         val graphicsData = ArrayList<GraphicsInfo>()
         var graphics: ZebraGraphics? = null
         try {
@@ -166,26 +208,18 @@ class LinkOSCard : CustomByteProtocol<Bitmap> {
 
             // This is grossly simplifying - in reality there are more options than just Color or MonoK - GrayDye for example
             val printType = if (installedRibbon.contains(COLOR_OPTION, true)) { PrintType.Color } else { PrintType.MonoK }
-            // Front Side
-            val zebraCardImage = drawImage(graphics, printType, imageData, 0, 0, 0, 0, context)
-            graphicsData.add(addImage(CardSide.Front, printType, 0, 0, -1, zebraCardImage))
 
-            // Front Side Overlay
-            if (isPrintTypeSupported(installedRibbon, OVERLAY_RIBBON_OPTIONS)) {
-                graphicsData.add(addImage(CardSide.Front, PrintType.Overlay, 0, 0, 1, null))
-            }
+            for (cardSide in cardSides) {
+                // Image
+                val zebraCardImage = drawImage(graphics, printType, imageData, 0, 0, 0, 0, context)
+                graphicsData.add(addImage(cardSide, printType, 0, 0, -1, zebraCardImage))
 
-            if (doubleSided) {
-                // Back Side
-                // If we are introducing native double-sided cards, we would load a new page here
-                graphicsData.add(addImage(CardSide.Back, printType, 0, 0, -1, zebraCardImage))
-
-                // Back Side Overlay
+                // Overlay
                 if (isPrintTypeSupported(installedRibbon, OVERLAY_RIBBON_OPTIONS)) {
-                    graphicsData.add(addImage(CardSide.Back, PrintType.Overlay, 0, 0, 1, null))
+                    graphicsData.add(addImage(cardSide, PrintType.Overlay, 0, 0, 1, null))
                 }
+
             }
-            // If we are introducing native double-sided cards, this needs to be placed after the front side
             graphics.clear()
         } finally {
             graphics?.close()

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
@@ -108,23 +108,23 @@ class LinkOSCard : CustomByteProtocol<Bitmap> {
 
                 var printJobs = mutableListOf<List<GraphicsInfo>>()
                 var pageoffset = 0
-                for (pagegroup in pagegroups) {
+                for (groupsize in pagegroups) {
                     if (forceDoubleSided) {
                         // User requested to print everything double sided, so we will - no matter what.
                         // A 2-page document will in this case yield 2 cards:
                         // - card 1: page 1 + page 1
                         // - card 2: page 2 + page 2
-                        for (i in 0 until pagegroup) {
+                        for (i in 0 until groupsize) {
                             printJobs.add(drawGraphics(zebraCardPrinter, pages[pageoffset + i].get(60, TimeUnit.SECONDS), listOf(CardSide.Front, CardSide.Back), context))
                         }
-                    } else if (canDoubleSided && pagegroup > 1) {
+                    } else if (canDoubleSided && groupsize > 1) {
                         // User did not requested everything to be printer double sided, but the printer
                         // is still capable printing on both sides and the current group of pages is actually
                         // more than one page. In this case, we print page 1 and 2 on one card.
                         // Even remainders of the pagegroup will be processed as double sided prints,
                         // any remainder will be printed on a single-sided card.
-                        for (i in 0 until pagegroup) {
-                            if (i % 2 == 0 && i == pagegroup-1) {
+                        for (i in 0 until groupsize) {
+                            if (i % 2 == 0 && i == groupsize-1) {
                                 // Even page (0, 2, 4, ...) and at last page of the group
                                 // --> Last page to print onto a single sided card
                                 printJobs.add(drawGraphics(zebraCardPrinter, pages[pageoffset + i].get(60, TimeUnit.SECONDS), listOf(CardSide.Front), context))
@@ -140,11 +140,11 @@ class LinkOSCard : CustomByteProtocol<Bitmap> {
                         }
                     } else {
                         // One page goes on one side of one card.
-                        for (i in 0 until pagegroup) {
+                        for (i in 0 until groupsize) {
                             printJobs.add(drawGraphics(zebraCardPrinter, pages[pageoffset + i].get(60, TimeUnit.SECONDS), listOf(CardSide.Front), context))
                         }
                     }
-                    pageoffset += pagegroup
+                    pageoffset += groupsize
                 }
 
                 for (job in printJobs) {

--- a/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
+++ b/pretixprint/app/src/full/java/eu/pretix/pretixprint/byteprotocols/LinkOSCard.kt
@@ -145,37 +145,38 @@ class LinkOSCard : CustomByteProtocol<Bitmap> {
                         }
                     }
                     pageoffset += groupsize
-                }
 
-                for (job in printJobs) {
-                    zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.CARD_SOURCE, cardSource)
-                    zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.CARD_DESTINATION, cardDestination)
-                    zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.DELETE_AFTER, "yes")
+                    for (job in printJobs) {
+                        zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.CARD_SOURCE, cardSource)
+                        zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.CARD_DESTINATION, cardDestination)
+                        zebraCardPrinter.setJobSetting(ZebraCardJobSettingNames.DELETE_AFTER, "yes")
 
-                    val jobId = zebraCardPrinter.print(1, job)
+                        val jobId = zebraCardPrinter.print(1, job)
 
-                    // Zebra Card printers only have a limited Job Buffer - in the case of the ZC-Series, it's
-                    // 4 print jobs.
-                    // This infinite loop is on purpose, as having a page-local timeout could lead to lost
-                    // pages on giant print jobs and a global timeout could lead to prematurely aborted
-                    // print jobs missing pages at the end.
-                    // However: We are polling for with a jobId and are checking if the printer is
-                    // readyForNextJob, which offers two ways out of a stuck print job and by extension,
-                    // an infinite loop:
-                    // - Either the blocking condition (empty ribbon, no more cards, stuck cards...) is
-                    //   resolved and the printer reverts to being readyForNextJob and the job is completed
-                    //   as intended, breaking the loop.
-                    // - Or the printer is power-cycled, leading to requesting the jobStatus with a
-                    //   specific jobId to throw an exception. In this case the loop is still broken and
-                    //   the print job spooling prematurely ended.
-                    while (true) {
-                        val jobStatusInfo = zebraCardPrinter.getJobStatus(jobId)
-                        if (jobStatusInfo.readyForNextJob) {
-                            break
-                        } else {
-                            Thread.sleep(2000)
+                        // Zebra Card printers only have a limited Job Buffer - in the case of the ZC-Series, it's
+                        // 4 print jobs.
+                        // This infinite loop is on purpose, as having a page-local timeout could lead to lost
+                        // pages on giant print jobs and a global timeout could lead to prematurely aborted
+                        // print jobs missing pages at the end.
+                        // However: We are polling for with a jobId and are checking if the printer is
+                        // readyForNextJob, which offers two ways out of a stuck print job and by extension,
+                        // an infinite loop:
+                        // - Either the blocking condition (empty ribbon, no more cards, stuck cards...) is
+                        //   resolved and the printer reverts to being readyForNextJob and the job is completed
+                        //   as intended, breaking the loop.
+                        // - Or the printer is power-cycled, leading to requesting the jobStatus with a
+                        //   specific jobId to throw an exception. In this case the loop is still broken and
+                        //   the print job spooling prematurely ended.
+                        while (true) {
+                            val jobStatusInfo = zebraCardPrinter.getJobStatus(jobId)
+                            if (jobStatusInfo.readyForNextJob) {
+                                break
+                            } else {
+                                Thread.sleep(2000)
+                            }
                         }
                     }
+                    printJobs.clear()
                 }
                 Thread.sleep(2000)
             } finally {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/BrotherRaster.kt
@@ -186,6 +186,7 @@ class BrotherRaster : StreamByteProtocol<Bitmap> {
 
     override fun send(
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         istream: InputStream,
         ostream: OutputStream,
         conf: Map<String, String>,

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/ESCLabel.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/ESCLabel.kt
@@ -78,6 +78,7 @@ class ESCLabel : StreamByteProtocol<Bitmap> {
 
     override fun send(
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         istream: InputStream,
         ostream: OutputStream,
         conf: Map<String, String>,

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/ESCPOS.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/ESCPOS.kt
@@ -31,6 +31,7 @@ open class ESCPOS : StreamByteProtocol<ByteArray> {
 
     override fun send(
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         istream: InputStream,
         ostream: OutputStream,
         conf: Map<String, String>,

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/FGL.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/FGL.kt
@@ -96,6 +96,7 @@ class FGL : StreamByteProtocol<Bitmap> {
 
     override fun send(
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         istream: InputStream,
         ostream: OutputStream,
         conf: Map<String, String>,

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/GraphicESCPOS.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/GraphicESCPOS.kt
@@ -111,6 +111,7 @@ class GraphicESCPOS : StreamByteProtocol<Bitmap> {
 
     override fun send(
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         istream: InputStream,
         ostream: OutputStream,
         conf: Map<String, String>,

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/GraphicePOSPrintXML.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/GraphicePOSPrintXML.kt
@@ -34,16 +34,16 @@ class GraphicePOSPrintXML : CustomByteProtocol<Bitmap> {
         return Bitmap::class.java
     }
 
-    override fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
-        ePOSPrintXML().sendNetwork(host, port, pages, conf, type, context)
+    override fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
+        ePOSPrintXML().sendNetwork(host, port, pages, pagegroups, conf, type, context)
     }
 
-    override fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
-        ePOSPrintXML().sendUSB(usbManager, usbDevice, pages, conf, type, context)
+    override fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
+        ePOSPrintXML().sendUSB(usbManager, usbDevice, pages, pagegroups, conf, type, context)
     }
 
-    override fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
-        ePOSPrintXML().sendBluetooth(deviceAddress, pages, conf, type, context)
+    override fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
+        ePOSPrintXML().sendBluetooth(deviceAddress, pages, pagegroups, conf, type, context)
     }
 
     override fun allowedForConnection(type: ConnectionType): Boolean {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/Interface.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/Interface.kt
@@ -27,17 +27,17 @@ sealed interface ByteProtocolInterface<T> {
 }
 
 interface StreamByteProtocol<T> : ByteProtocolInterface<T> {
-    fun send(pages: List<CompletableFuture<ByteArray>>, istream: InputStream, ostream: OutputStream, conf: Map<String, String>, type: String, waitAfterPage: Long)
+    fun send(pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, istream: InputStream, ostream: OutputStream, conf: Map<String, String>, type: String, waitAfterPage: Long)
 }
 
 interface CustomByteProtocol<T> : ByteProtocolInterface<T> {
-    fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context)
-    fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context)
-    fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context)
+    fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context)
+    fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context)
+    fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context)
 }
 
 interface SunmiByteProtocol<T> : ByteProtocolInterface<T> {
-    fun sendSunmi(printer: PrinterSdk.Printer, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, waitAfterPage: Long)
+    fun sendSunmi(printer: PrinterSdk.Printer, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, waitAfterPage: Long)
 }
 
 fun getProtoClass(proto: String): ByteProtocolInterface<Any> {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/PNG.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/PNG.kt
@@ -46,6 +46,7 @@ class PNG : SunmiByteProtocol<Bitmap> {
     override fun sendSunmi(
         printer: Printer,
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         conf: Map<String, String>,
         type: String,
         waitAfterPage: Long

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/SLCS.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/SLCS.kt
@@ -105,6 +105,7 @@ class SLCS : StreamByteProtocol<Bitmap> {
 
     override fun send(
         pages: List<CompletableFuture<ByteArray>>,
+        pagegroups: List<Int>,
         istream: InputStream,
         ostream: OutputStream,
         conf: Map<String, String>,

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/ePOSPrintXML.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/byteprotocols/ePOSPrintXML.kt
@@ -39,7 +39,7 @@ class ePOSPrintXML : CustomByteProtocol<ByteArray> {
         return ByteArray::class.java
     }
 
-    override fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendNetwork(host: String, port: Int, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         fun getSetting(key: String, def: String): String {
             return conf[key] ?: PreferenceManager.getDefaultSharedPreferences(context).getString(key, def)!!
         }
@@ -77,11 +77,11 @@ class ePOSPrintXML : CustomByteProtocol<ByteArray> {
         }
     }
 
-    override fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendUSB(usbManager: UsbManager, usbDevice: UsbDevice, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         TODO("Not yet implemented")
     }
 
-    override fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, conf: Map<String, String>, type: String, context: Context) {
+    override fun sendBluetooth(deviceAddress: String, pages: List<CompletableFuture<ByteArray>>, pagegroups: List<Int>, conf: Map<String, String>, type: String, context: Context) {
         TODO("Not yet implemented")
     }
 

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Bluetooth.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Bluetooth.kt
@@ -31,7 +31,7 @@ class BluetoothConnection : ConnectionType {
         return true
     }
 
-    override fun print(tmpfile: File, numPages: Int, context: Context, type: String, settings: Map<String, String>?) {
+    override fun print(tmpfile: File, numPages: Int, pagegroups: List<Int>, context: Context, type: String, settings: Map<String, String>?) {
         this.context = context
 
         val conf = settings?.toMutableMap() ?: mutableMapOf()
@@ -105,7 +105,7 @@ class BluetoothConnection : ConnectionType {
                         try {
                             Log.i("PrintService", "[$type] Start proto.send()")
                             val wap = Integer.valueOf(conf.get("hardware_${type}printer_waitafterpage") ?: "2000").toLong()
-                            proto.send(futures, istream, ostream, conf, type, wap)
+                            proto.send(futures, pagegroups, istream, ostream, conf, type, wap)
                             Log.i("PrintService", "[$type] Finished proto.send()")
                         } finally {
                             socket.close()
@@ -114,7 +114,7 @@ class BluetoothConnection : ConnectionType {
 
                     is CustomByteProtocol<*> -> {
                         Log.i("PrintService", "[$type] Start proto.sendBluetooth()")
-                        proto.sendBluetooth(device.address, futures, conf, type, context)
+                        proto.sendBluetooth(device.address, futures, pagegroups, conf, type, context)
                         Log.i("PrintService", "[$type] Finished proto.sendBluetooth()")
                     }
                     is SunmiByteProtocol -> {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/CUPS.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/CUPS.kt
@@ -21,7 +21,7 @@ class CUPSConnection : ConnectionType {
         return type != "receipt"
     }
 
-    override fun print(tmpfile: File, numPages: Int, context: Context, type: String, settings: Map<String, String>?) {
+    override fun print(tmpfile: File, numPages: Int, pagegroups: List<Int>, context: Context, type: String, settings: Map<String, String>?) {
         val conf = settings ?: emptyMap()
         fun getSetting(key: String, def: String): String {
             return conf!![key] ?: PreferenceManager.getDefaultSharedPreferences(context).getString(key, def)!!

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/IMin.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/IMin.kt
@@ -24,7 +24,7 @@ class IMinInternalConnection : USBConnection() {
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    override fun print(tmpfile: File, numPages: Int, context: Context, type: String, settings: Map<String, String>?) {
+    override fun print(tmpfile: File, numPages: Int, pagegroups: List<Int>, context: Context, type: String, settings: Map<String, String>?) {
         var iNeostraInterfaces: INeostraInterfaces? = null
         val conn = object : ServiceConnection {
             override fun onServiceConnected(componentName: ComponentName, iBinder: IBinder) {
@@ -69,7 +69,7 @@ class IMinInternalConnection : USBConnection() {
             iNeostraInterfaces?.openCashbox()
         }
 
-        super.print(tmpfile, numPages, context, type, settings)
+        super.print(tmpfile, numPages, pagegroups, context, type, settings)
     }
 
 }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Interface.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Interface.kt
@@ -15,7 +15,7 @@ interface ConnectionType {
     val inputType: Input
 
     fun allowedForUsecase(type: String): Boolean
-    fun print(tmpfile: File, numPages: Int, context: Context, useCase: String, settings: Map<String, String>? = null)
+    fun print(tmpfile: File, numPages: Int, pagegroups: List<Int>, context: Context, useCase: String, settings: Map<String, String>? = null)
 
     fun isConfiguredFor(context: Context, type: String): Boolean {
         return !PreferenceManager.getDefaultSharedPreferences(context).getString("hardware_${type}printer_ip", "").isNullOrEmpty()

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Network.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Network.kt
@@ -25,7 +25,7 @@ class NetworkConnection : ConnectionType {
         return true
     }
 
-    override fun print(tmpfile: File, numPages: Int, context: Context, type: String, settings: Map<String, String>?) {
+    override fun print(tmpfile: File, numPages: Int, pagegroups: List<Int>, context: Context, type: String, settings: Map<String, String>?) {
         val conf = settings?.toMutableMap() ?: mutableMapOf()
         for (entry in PreferenceManager.getDefaultSharedPreferences(context).all.iterator()) {
             if (!conf.containsKey(entry.key)) {
@@ -66,7 +66,7 @@ class NetworkConnection : ConnectionType {
                         try {
                             Log.i("PrintService", "[$type] Start proto.send()")
                             val wap = Integer.valueOf(conf.get("hardware_${type}printer_waitafterpage") ?: "2000").toLong()
-                            proto.send(futures, istream, ostream, conf, type, wap)
+                            proto.send(futures, pagegroups, istream, ostream, conf, type, wap)
                             Log.i("PrintService", "[$type] Finished proto.send()")
                         } finally {
                             istream.close()
@@ -77,7 +77,7 @@ class NetworkConnection : ConnectionType {
 
                     is CustomByteProtocol<*> -> {
                         Log.i("PrintService", "[$type] Start proto.sendNetwork()")
-                        proto.sendNetwork(serverAddr.hostAddress, port, futures, conf, type, context)
+                        proto.sendNetwork(serverAddr.hostAddress, port, futures, pagegroups, conf, type, context)
                         Log.i("PrintService", "[$type] Finished proto.sendNetwork()")
                     }
                     is SunmiByteProtocol -> {

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Sunmi.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/Sunmi.kt
@@ -29,7 +29,7 @@ class SunmiInternalConnection : ConnectionType {
         return Build.BRAND.uppercase() == "SUNMI"
     }
 
-    override fun print(tmpfile: File, numPages: Int, context: Context, type: String, settings: Map<String, String>?) {
+    override fun print(tmpfile: File, numPages: Int, pagegroups: List<Int>, context: Context, type: String, settings: Map<String, String>?) {
         val conf = settings?.toMutableMap() ?: mutableMapOf()
         for (entry in PreferenceManager.getDefaultSharedPreferences(context).all.iterator()) {
             if (!conf.containsKey(entry.key)) {
@@ -93,7 +93,7 @@ class SunmiInternalConnection : ConnectionType {
                             override fun onDefPrinter(printer: PrinterSdk.Printer?) {
                                 if (printer != null) {
                                     try {
-                                        proto.sendSunmi(printer, futures, conf, type, wap)
+                                        proto.sendSunmi(printer, futures, pagegroups, conf, type, wap)
                                         future.complete(null)
                                     } catch (e: Exception) {
                                         future.completeExceptionally(e)

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/System.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/System.kt
@@ -30,6 +30,7 @@ class SystemConnection : ConnectionType {
     override fun print(
         tmpfile: File,
         numPages: Int,
+        pagegroups: List<Int>,
         context: Context,
         useCase: String,
         settings: Map<String, String>?

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/connections/USB.kt
@@ -312,7 +312,7 @@ open class USBConnection : ConnectionType {
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    override fun print(tmpfile: File, numPages: Int, context: Context, type: String, settings: Map<String, String>?) {
+    override fun print(tmpfile: File, numPages: Int, pagegroups: List<Int>, context: Context, type: String, settings: Map<String, String>?) {
         val conf = settings?.toMutableMap() ?: mutableMapOf()
         for (entry in PreferenceManager.getDefaultSharedPreferences(context).all.iterator()) {
             if (!conf.containsKey(entry.key)) {
@@ -395,7 +395,7 @@ open class USBConnection : ConnectionType {
                                             try {
                                                 Log.i("PrintService", "[$type] Start proto.send()")
                                                 val wap = Integer.valueOf(conf.get("hardware_${type}printer_waitafterpage") ?: "2000").toLong()
-                                                proto.send(futures, istream, ostream, conf, type, wap)
+                                                proto.send(futures, pagegroups, istream, ostream, conf, type, wap)
                                                 Log.i("PrintService", "[$type] Finished proto.send()")
                                             } finally {
                                                 istream.close()
@@ -405,7 +405,7 @@ open class USBConnection : ConnectionType {
 
                                         is CustomByteProtocol<*> -> {
                                             Log.i("PrintService", "[$type] Start proto.sendUSB()")
-                                            proto.sendUSB(manager, device, futures, conf, type, context)
+                                            proto.sendUSB(manager, device, futures, pagegroups, conf, type, context)
                                             Log.i("PrintService", "[$type] Finished proto.sendUSB()")
                                         }
                                         

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/TestPrint.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/TestPrint.kt
@@ -66,33 +66,33 @@ fun testPrint(context: Context, protoName: String, mode: String, useCase: String
 
     when (mode) {
         NetworkConnection().identifier -> {
-            NetworkConnection().print(file, 1, context, useCase, settings)
+            NetworkConnection().print(file, 1, listOf(1), context, useCase, settings)
         }
         BluetoothConnection().identifier -> {
-            BluetoothConnection().print(file, 1, context, useCase, settings)
+            BluetoothConnection().print(file, 1, listOf(1), context, useCase, settings)
         }
         CUPSConnection().identifier -> {
-            CUPSConnection().print(file, 1, context, useCase, settings)
+            CUPSConnection().print(file, 1, listOf(1), context, useCase, settings)
         }
         SunmiInternalConnection().identifier -> {
-            SunmiInternalConnection().print(file, 1, context, useCase, settings)
+            SunmiInternalConnection().print(file, 1, listOf(1), context, useCase, settings)
         }
         IMinInternalConnection().identifier -> {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                IMinInternalConnection().print(file, 1, context, useCase, settings)
+                IMinInternalConnection().print(file, 1, listOf(1), context, useCase, settings)
             } else {
                 throw Exception("iMin USB not supported on this Android version.")
             }
         }
         USBConnection().identifier -> {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                USBConnection().print(file, 1, context, useCase, settings)
+                USBConnection().print(file, 1, listOf(1), context, useCase, settings)
             } else {
                 throw Exception("USB not supported on this Android version.")
             }
         }
         SystemConnection().identifier -> {
-            SystemConnection().print(file, 1, context, useCase, settings)
+            SystemConnection().print(file, 1, listOf(1), context, useCase, settings)
         }
     }
 }

--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/SystemPrintActivity.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/SystemPrintActivity.kt
@@ -16,6 +16,7 @@ class SystemPrintActivity : AppCompatActivity() {
         const val INTENT_EXTRA_CALLER = "caller"
         const val INTENT_EXTRA_FILE = "tmpfile"
         const val INTENT_EXTRA_PAGENUM = "pagenum"
+        const val INTENT_EXTRA_PAGEGROUPS = "pagegroups"
         const val INTENT_EXTRA_TYPE = "type"
     }
 
@@ -32,9 +33,10 @@ class SystemPrintActivity : AppCompatActivity() {
 
         val tmpfile = intent.extras?.get(INTENT_EXTRA_FILE) as File
         val pagenum = intent.extras?.get(INTENT_EXTRA_PAGENUM) as Int
+        val pagegroups = intent.extras?.get(INTENT_EXTRA_PAGEGROUPS) as List<Int>
         val type = intent.extras?.get(INTENT_EXTRA_TYPE) as String
 
-        SystemConnection().print(tmpfile, pagenum, this, type, null)
+        SystemConnection().print(tmpfile, pagenum, pagegroups, this, type, null)
         hadLaunchedPrint = true
     }
 


### PR DESCRIPTION
This adds facilities for double sided printing (mainly through exposing which pages belong together into a single group --> `pagegroups`.

As a proof of concept, there is also an implementation for the Zebra ZC300.

All other renderers will ignore the new `pagegroup`-parameters for now and just print/behave as before.

ToDo:
 - [x] instead of renderering all jobs and then spooling them, imitate the previous behavior, where a printjob is created and dispatched right away and then more jobs are queued up while waiting for the previous jobs to terminate.