### PR TITLE
Ask user for USE_FULL_SCREEN_INTENT permission

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/PrinterSetupActivity.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/ui/PrinterSetupActivity.kt
@@ -33,7 +33,7 @@ class PrinterSetupActivity : AppCompatActivity() {
     var settingsStagingArea = mutableMapOf<String, String>()
     val fragmentManager = supportFragmentManager
     lateinit var fragment: SetupFragment
-    lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
+    lateinit var requestPermissionLauncher: ActivityResultLauncher<Array<String>>
     lateinit var useCase: String
 
     fun mode(): String {
@@ -58,8 +58,8 @@ class PrinterSetupActivity : AppCompatActivity() {
         }
 
         requestPermissionLauncher =
-            registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
-                if (isGranted) {
+            registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { grantMap: Map<String, Boolean> ->
+                if (!grantMap.containsValue(false)) {
                     startConnectionSettings()
                 }
             }
@@ -132,9 +132,17 @@ class PrinterSetupActivity : AppCompatActivity() {
             settingsStagingArea.put("hardware_${useCase}printer_mode", "")
             settingsStagingArea.put("hardware_${useCase}printer_ip", "")
             settingsStagingArea.put("hardware_${useCase}printer_printername", "")
+            val perms = mutableListOf<String>()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && ContextCompat.checkSelfPermission(
                     applicationContext, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
-                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                perms.add(Manifest.permission.POST_NOTIFICATIONS)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && ContextCompat.checkSelfPermission(
+                    applicationContext, Manifest.permission.USE_FULL_SCREEN_INTENT) != PackageManager.PERMISSION_GRANTED) {
+                perms.add(Manifest.permission.USE_FULL_SCREEN_INTENT)
+            }
+            if (perms.isNotEmpty()) {
+                requestPermissionLauncher.launch(perms.toTypedArray())
                 return
             }
             return startFinalPage()

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -38,7 +38,7 @@
     <string name="notification_permission_required_summary">Klicken Sie hier, um die Berechtigung zu erteilen. Wenn kein Berechtigungsdialog erscheint, müssen Sie die Berechtigung manuell in den Systemeinstellungen unter Apps → pretixPRINT → Berechtigungen erteilen.</string>
     <string name="battery_optimizations_required">Bitte erlauben Sie die Hintergrundnutzung dieser App.</string>
     <string name="battery_optimizations_required_summary">Drucken funktioniert nur verlässlich, wenn die Akku-Optimierungen für diese App ausgeschaltet sind. Klicken Sie hier, wählen Sie dann "Alle Apps", suchen Sie pretixPRINT and stellen Sie Akku-Optimierungen oder -Einschränkungen für die App ab.</string>
-    <string name="fullscreen_permission_required">Die App fehlt die Berechtigung für Vollbild. Dies verhindert Drucken über das Android Drucksystem.</string>
+    <string name="fullscreen_permission_required">Die App fehlt die Berechtigung für Vollbild-Dialoge. Dies verhindert Drucken über das Android-Drucksystem.</string>
     <string name="fullscreen_permission_required_summary">Klicken Sie hier, um die Berechtigung zu erteilen. Wenn kein Berechtigungsdialog erscheint, müssen Sie die Berechtigung manuell in den Systemeinstellungen unter Apps → pretixPRINT → Berechtigungen erteilen.</string>
     <string name="headline_found_network_printers">Gefundene Netzwerkdrucker</string>
     <string name="headline_found_bluetooth_printers">Gefundene Bluetoothdrucker</string>

--- a/pretixprint/app/src/main/res/values-de/strings.xml
+++ b/pretixprint/app/src/main/res/values-de/strings.xml
@@ -38,6 +38,8 @@
     <string name="notification_permission_required_summary">Klicken Sie hier, um die Berechtigung zu erteilen. Wenn kein Berechtigungsdialog erscheint, müssen Sie die Berechtigung manuell in den Systemeinstellungen unter Apps → pretixPRINT → Berechtigungen erteilen.</string>
     <string name="battery_optimizations_required">Bitte erlauben Sie die Hintergrundnutzung dieser App.</string>
     <string name="battery_optimizations_required_summary">Drucken funktioniert nur verlässlich, wenn die Akku-Optimierungen für diese App ausgeschaltet sind. Klicken Sie hier, wählen Sie dann "Alle Apps", suchen Sie pretixPRINT and stellen Sie Akku-Optimierungen oder -Einschränkungen für die App ab.</string>
+    <string name="fullscreen_permission_required">Die App fehlt die Berechtigung für Vollbild. Dies verhindert Drucken über das Android Drucksystem.</string>
+    <string name="fullscreen_permission_required_summary">Klicken Sie hier, um die Berechtigung zu erteilen. Wenn kein Berechtigungsdialog erscheint, müssen Sie die Berechtigung manuell in den Systemeinstellungen unter Apps → pretixPRINT → Berechtigungen erteilen.</string>
     <string name="headline_found_network_printers">Gefundene Netzwerkdrucker</string>
     <string name="headline_found_bluetooth_printers">Gefundene Bluetoothdrucker</string>
     <string name="headline_add_printer">Drucker konfigurieren</string>

--- a/pretixprint/app/src/main/res/values/strings.xml
+++ b/pretixprint/app/src/main/res/values/strings.xml
@@ -40,6 +40,8 @@
     <string name="notification_permission_required_summary">Click here to grant the permission. If no permission dialog shows, you need to grant the permission manually in system settings at Apps → pretixPRINT → Permissions.</string>
     <string name="battery_optimizations_required">Please allow unrestricted background usage for this app.</string>
     <string name="battery_optimizations_required_summary">Printing only works reliably if battery optimizations are turned off for this app. Please click here, then select "All Apps", find pretixPRINT and turn off battery optimizations or restrictions.</string>
+    <string name="fullscreen_permission_required">The app is not granted permission to open in full screen. This will prevent printing with the Android System printer.</string>
+    <string name="fullscreen_permission_required_summary">Click here to grant the permission. If no permission dialog shows, you need to grant the permission manually in system settings at Apps → pretixPRINT → Permissions.</string>
     <string name="headline_found_network_printers">Found network printers</string>
     <string name="headline_found_usb_devices">Found USB devices</string>
     <string name="headline_found_bluetooth_printers">Found bluetooth printers</string>

--- a/pretixprint/app/src/main/res/xml/preferences.xml
+++ b/pretixprint/app/src/main/res/xml/preferences.xml
@@ -8,6 +8,12 @@
         />
 
     <eu.pretix.pretixprint.ui.WarningPreference
+        android:key="fullscreen_permission"
+        android:title="@string/fullscreen_permission_required"
+        android:summary="@string/fullscreen_permission_required_summary"
+        />
+
+    <eu.pretix.pretixprint.ui.WarningPreference
         android:key="battery_optimizations"
         android:title="@string/battery_optimizations_required"
         android:summary="@string/battery_optimizations_required_summary"


### PR DESCRIPTION
Ask the user in the system printer setup flow for the USE_FULL_SCREEN_INTENT permission.

For users that already set up that printer before this update, a new permission warning bar is added to the main screen.