### PR TITLE
Fix crash if payment was card, but manually confirmed

### DIFF
--- a/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/ESCPOSRenderer.kt
+++ b/pretixprint/app/src/main/java/eu/pretix/pretixprint/print/ESCPOSRenderer.kt
@@ -293,7 +293,12 @@ class ESCPOSRenderer(private val dialect: Dialect, private val receipt: JSONObje
                 }
             }
             "paymentlines" -> {
-                when (receipt.getString("payment_type")) {
+                if (receipt.has("payment_data") &&
+                    receipt.getJSONObject("payment_data").has("source") &&
+                    receipt.getJSONObject("payment_data").getString("source") == "manual") {
+                    text(ctx.getString(R.string.receiptline_paidcard))
+                    newline()
+                } else when (receipt.getString("payment_type")) {
                     "square_pos" -> {
                         emphasize(true)
                         text(ctx.getString(R.string.receiptline_paidcard))


### PR DESCRIPTION
This can happen if a card payment (sumup, terminal_zvt) had to be manually confirmed, because the card reader returned an unknown transaction state. In this case the `payment_data` object only contains `"source": "manual"`